### PR TITLE
Simple admin password

### DIFF
--- a/app/assets/stylesheets/static.sass
+++ b/app/assets/stylesheets/static.sass
@@ -8,8 +8,21 @@ body
 
   h2
     color: #fff
-    font-size: 60px
+    font-size: 40px
     text-shadow: 1px 1px 60px #000
 
   img
     margin-top: 50px
+
+  form
+    background-color: #000
+    color: #fff
+    margin: 0 auto
+    width: 800px
+
+    h1
+      font-size: 60px
+
+    input
+      font-size: 20px
+      margin-bottom: 20px

--- a/app/assets/stylesheets/static.sass
+++ b/app/assets/stylesheets/static.sass
@@ -4,5 +4,8 @@ body
   padding: 0
   text-align: center
 
+  h2
+    color: #fff
+
   img
     margin-top: 50px

--- a/app/assets/stylesheets/static.sass
+++ b/app/assets/stylesheets/static.sass
@@ -1,11 +1,15 @@
 body
-  background-color: #000
+  background: image-url('monolith.jpg') no-repeat center center fixed
+  background-size: cover
   margin: 0
   padding: 0
   text-align: center
+  font-family: verdana
 
   h2
     color: #fff
+    font-size: 60px
+    text-shadow: 1px 1px 60px #000
 
   img
     margin-top: 50px

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -12,6 +12,7 @@ class ApplicationController < ActionController::Base
   def ensure_admin
     return if session_password_matches?
     session.clear
+    session[:redirect_to] = request.path
     redirect_to sign_in_path
   end
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,3 +1,17 @@
 class ApplicationController < ActionController::Base
   protect_from_forgery with: :exception
+
+  before_action :ensure_admin
+
+  private
+
+  def session_password_matches?
+    Rails.application.secrets[:admin_password] == session[:admin_password]
+  end
+
+  def ensure_admin
+    return if session_password_matches?
+    session.clear
+    redirect_to sign_in_path
+  end
 end

--- a/app/controllers/faring_direball_controller.rb
+++ b/app/controllers/faring_direball_controller.rb
@@ -1,4 +1,6 @@
 class FaringDireballController < ApplicationController
+  skip_before_action :ensure_admin
+
   def index
     url = 'https://daringfireball.net/feeds/json'
 

--- a/app/controllers/password_controller.rb
+++ b/app/controllers/password_controller.rb
@@ -1,0 +1,27 @@
+class PasswordController < ApplicationController
+  skip_before_action :ensure_admin
+
+  def create
+    if password_matches?
+      session.clear
+      session[:admin_password] = params[:admin_password]
+      flash[:notice] = 'Password saved to session'
+      redirect_to root_path
+    else
+      flash[:error] = 'Password did not match'
+      redirect_to sign_in_path
+    end
+  end
+
+  def clear
+    session.clear
+    flash[:notice] = 'Password removed from session'
+    redirect_to root_path
+  end
+
+  private
+
+  def password_matches?
+    Rails.application.secrets[:admin_password] == params[:admin_password]
+  end
+end

--- a/app/controllers/password_controller.rb
+++ b/app/controllers/password_controller.rb
@@ -3,10 +3,11 @@ class PasswordController < ApplicationController
 
   def create
     if password_matches?
+      path = session.fetch(:redirect_to, root_path)
       session.clear
       session[:admin_password] = params[:admin_password]
       flash[:notice] = 'Password saved to session'
-      redirect_to root_path
+      redirect_to path
     else
       flash[:error] = 'Password did not match'
       redirect_to sign_in_path

--- a/app/controllers/static_controller.rb
+++ b/app/controllers/static_controller.rb
@@ -1,2 +1,3 @@
 class StaticController < ApplicationController
+  skip_before_action :ensure_admin
 end

--- a/app/views/password/new.html.haml
+++ b/app/views/password/new.html.haml
@@ -1,0 +1,8 @@
+%h1 Admin Password
+
+- if flash[:error]
+  %h2= flash[:error]
+
+= form_for :admin_password do |f|
+  = password_field_tag :admin_password
+  = f.submit 'Sign In'

--- a/app/views/password/new.html.haml
+++ b/app/views/password/new.html.haml
@@ -1,8 +1,11 @@
-%h1 Admin Password
-
-- if flash[:error]
-  %h2= flash[:error]
+- content_for :head do
+  = stylesheet_link_tag 'static', media: 'all'
 
 = form_for :admin_password do |f|
+  %h1 Admin Password
+
+  - if flash[:error]
+    %h2= flash[:error]
+
   = password_field_tag :admin_password
   = f.submit 'Sign In'

--- a/app/views/static/root.html.haml
+++ b/app/views/static/root.html.haml
@@ -3,5 +3,3 @@
 
 - if flash[:notice]
   %h2= flash[:notice]
-
-= image_tag 'monolith.jpg'

--- a/app/views/static/root.html.haml
+++ b/app/views/static/root.html.haml
@@ -1,4 +1,7 @@
 - content_for :head do
   = stylesheet_link_tag 'static', media: 'all'
 
+- if flash[:notice]
+  %h2= flash[:notice]
+
 = image_tag 'monolith.jpg'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,10 @@
 Rails.application.routes.draw do
   resources :projects, only: %i[create index update]
   get 'faring_direball', to: 'faring_direball#index'
+
+  get 'sign_in', to: 'password#new', as: :sign_in
+  post 'sign_in', to: 'password#create'
+  get 'sign_out', to: 'password#clear', as: :sign_out
+
   root to: 'static#root'
 end

--- a/config/secrets.yml
+++ b/config/secrets.yml
@@ -18,9 +18,11 @@
 # Environmental secrets are only available for that specific environment.
 
 development:
+  admin_password: shhh
   secret_key_base: 6a5341fa5e7e62d144961615bf689f6fbe223331370b316df623f1f34102fe16a4d5f863a84adca18345211d5d83cf4811af4735f2d483be129a465c1f2f429b
 
 test:
+  admin_password: shhh
   secret_key_base: 441b32a8fe24aa221e31087529f3dfde526fefb648ca4378084d78f66bbdede88a820163662732ec2d559d7487646a4ce543563a8df394d9f38e2c4c2583ada8
 
 # Do not keep production secrets in the unencrypted secrets file.
@@ -29,4 +31,5 @@ test:
 # and move the `production:` environment over there.
 
 production:
+  admin_password: <%= ENV["ADMIN_PASSWORD"] %>
   secret_key_base: <%= ENV["SECRET_KEY_BASE"] %>

--- a/spec/features/admin_password_spec.rb
+++ b/spec/features/admin_password_spec.rb
@@ -1,0 +1,30 @@
+require 'rails_helper'
+
+feature 'Admin Password' do
+  scenario 'signing in without redirect_to lands on home page' do
+    visit '/sign_in'
+    fill_in 'admin_password', with: 'shhh'
+    click_on 'Sign In'
+    expect(page).to have_content 'Password saved to session'
+    expect(current_path).to eq root_path
+  end
+
+  scenario 'signing in with redirect_to works' do
+    visit '/projects'
+    fill_in 'admin_password', with: 'shhh'
+    click_on 'Sign In'
+    expect(current_path).to eq '/projects'
+  end
+
+  scenario 'signing out clears session' do
+    visit '/sign_in'
+    fill_in 'admin_password', with: 'shhh'
+    click_on 'Sign In'
+    visit '/projects'
+    expect(current_path).to eq '/projects'
+    visit 'sign_out'
+    expect(page).to have_content 'Password removed from session'
+    visit '/projects'
+    expect(current_path).to eq sign_in_path
+  end
+end

--- a/spec/features/user_creates_new_project_spec.rb
+++ b/spec/features/user_creates_new_project_spec.rb
@@ -1,31 +1,30 @@
 require 'rails_helper'
 
 describe 'User creates new project', js: true do
-  before do
-    allow_any_instance_of(ApplicationController)
-      .to receive(:session_password_matches?).and_return(true)
-  end
+  context 'signed in as admin' do
+    include_context 'session password matches'
 
-  scenario 'creating first project' do
-    visit '/projects'
-    click_on 'Create Project'
-    fill_in 'name', with: 'First Project'
-    click_on 'Create'
+    scenario 'creating first project' do
+      visit '/projects'
+      click_on 'Create Project'
+      fill_in 'name', with: 'First Project'
+      click_on 'Create'
 
-    expect(page).to_not have_content 'No projects - create one!'
-    project_name = page.find('li .name').text
-    expect(project_name).to eq 'First Project'
-  end
+      expect(page).to_not have_content 'No projects - create one!'
+      project_name = page.find('li .name').text
+      expect(project_name).to eq 'First Project'
+    end
 
-  scenario 'error on duplicate projects' do
-    project = FactoryBot.create :project
+    scenario 'error on duplicate projects' do
+      project = FactoryBot.create :project
 
-    visit '/projects'
-    click_on 'Create Project'
-    fill_in 'name', with: project.name
-    click_on 'Create'
+      visit '/projects'
+      click_on 'Create Project'
+      fill_in 'name', with: project.name
+      click_on 'Create'
 
-    expect(page).to have_content 'Something went wrong - project not created!'
-    expect(page.all('li .name').count).to eq 1
+      expect(page).to have_content 'Something went wrong - project not created!'
+      expect(page.all('li .name').count).to eq 1
+    end
   end
 end

--- a/spec/features/user_creates_new_project_spec.rb
+++ b/spec/features/user_creates_new_project_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 describe 'User creates new project', js: true do
+  before do
+    allow_any_instance_of(ApplicationController)
+      .to receive(:session_password_matches?).and_return(true)
+  end
+
   scenario 'creating first project' do
     visit '/projects'
     click_on 'Create Project'

--- a/spec/features/user_updates_project_spec.rb
+++ b/spec/features/user_updates_project_spec.rb
@@ -1,21 +1,20 @@
 require 'rails_helper'
 
 feature 'User updates project', js: true do
-  before do
-    allow_any_instance_of(ApplicationController)
-      .to receive(:session_password_matches?).and_return(true)
-  end
+  context 'signed in as admin' do
+    include_context 'session password matches'
 
-  scenario 'project is updated' do
-    FactoryBot.create :project, name: 'Older'
-    project = FactoryBot.create :project
-    FactoryBot.create :project, name: 'Newer'
+    scenario 'project is updated' do
+      FactoryBot.create :project, name: 'Older'
+      project = FactoryBot.create :project
+      FactoryBot.create :project, name: 'Newer'
 
-    visit '/projects'
-    project_item = page.find('li', text: project.name)
-    project_item.click
+      visit '/projects'
+      project_item = page.find('li', text: project.name)
+      project_item.click
 
-    touched_projects = page.all('.touched')
-    expect(touched_projects.count).to eq 1
+      touched_projects = page.all('.touched')
+      expect(touched_projects.count).to eq 1
+    end
   end
 end

--- a/spec/features/user_updates_project_spec.rb
+++ b/spec/features/user_updates_project_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 feature 'User updates project', js: true do
+  before do
+    allow_any_instance_of(ApplicationController)
+      .to receive(:session_password_matches?).and_return(true)
+  end
+
   scenario 'project is updated' do
     FactoryBot.create :project, name: 'Older'
     project = FactoryBot.create :project

--- a/spec/features/user_views_project_list_spec.rb
+++ b/spec/features/user_views_project_list_spec.rb
@@ -1,6 +1,11 @@
 require 'rails_helper'
 
 feature 'User views project list', js: true do
+  before do
+    allow_any_instance_of(ApplicationController)
+      .to receive(:session_password_matches?).and_return(true)
+  end
+
   scenario 'with no projects' do
     visit '/projects'
     expect(page).to have_content 'No projects - create one!'

--- a/spec/features/user_views_project_list_spec.rb
+++ b/spec/features/user_views_project_list_spec.rb
@@ -1,24 +1,25 @@
 require 'rails_helper'
 
 feature 'User views project list', js: true do
-  before do
-    allow_any_instance_of(ApplicationController)
-      .to receive(:session_password_matches?).and_return(true)
-  end
+  include_examples 'admin password required', '/projects'
 
-  scenario 'with no projects' do
-    visit '/projects'
-    expect(page).to have_content 'No projects - create one!'
-  end
+  context 'signed in as admin' do
+    include_context 'session password matches'
 
-  scenario 'with a few projects' do
-    FactoryBot.create :project, name: '1st', touched_at: Time.zone.now + 1.day
-    FactoryBot.create :project, name: '2nd', touched_at: Time.zone.now - 1.day
-    FactoryBot.create :project, name: '3rd', touched_at: Time.zone.now
+    scenario 'with no projects' do
+      visit '/projects'
+      expect(page).to have_content 'No projects - create one!'
+    end
 
-    visit '/projects'
+    scenario 'with a few projects' do
+      FactoryBot.create :project, name: '1st', touched_at: Time.zone.now + 1.day
+      FactoryBot.create :project, name: '2nd', touched_at: Time.zone.now - 1.day
+      FactoryBot.create :project, name: '3rd', touched_at: Time.zone.now
 
-    project_names = page.all('li .name').map(&:text)
-    expect(project_names).to eq %w[2nd 3rd 1st]
+      visit '/projects'
+
+      project_names = page.all('li .name').map(&:text)
+      expect(project_names).to eq %w[2nd 3rd 1st]
+    end
   end
 end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -6,6 +6,8 @@ require 'rspec/rails'
 require 'webmock/rspec'
 # Add additional requires below this line. Rails is not loaded until this point!
 
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].each { |f| require f }
+
 ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|

--- a/spec/support/password_helpers.rb
+++ b/spec/support/password_helpers.rb
@@ -1,0 +1,15 @@
+shared_context 'session password matches' do
+  before do
+    allow_any_instance_of(ApplicationController)
+      .to receive(:session_password_matches?).and_return(true)
+  end
+end
+
+shared_examples 'admin password required' do |parameter|
+  let(:path) { parameter }
+
+  scenario 'redirected to sign in' do
+    visit path
+    expect(current_path).to eq sign_in_path
+  end
+end


### PR DESCRIPTION
This is my take on doing a simple admin password for a Rails app. The idea is to set a password in the ENV and then check that what is entered matches it. Once it's been matched, throw it in the session and it'll keep matching on subsequent requests.

In terms of testing, I have one spec file that actually going through these session mutations, but all other tests simply mock it out like this:

```
allow_any_instance_of(ApplicationController).to receive(:session_password_matches?).and_return(true)
```

But I also have a sanity check that routes requiring the admin password redirect to sign in when it's not present. That feels like the right level of coverage here:

* Ensure the password functionality works in one spec
* Ensure routes requiring password actually require it
* Don't worry about re-testing password requirements everywhere else, just mock it out

While I was at it, I also fixed up some styles.