### PR TITLE
Reset sequence and fetch data from web

### DIFF
--- a/lib/tasks/temp/migrate_rando.rake
+++ b/lib/tasks/temp/migrate_rando.rake
@@ -1,3 +1,4 @@
+require 'open-uri'
 require 'csv'
 
 task migrate_rando: :environment do
@@ -11,8 +12,8 @@ task migrate_rando: :environment do
     Character,  # belongs_to Player, Season
     Pick        # belongs_to Character, Week, Team
   ].each do |klass|
-    path = "export/#{klass.to_s.downcase}.csv"
-    rows = CSV.read(path, headers: true)
+    data = open("http://jonallured.com/rando/#{klass.to_s.downcase}.csv").read
+    rows = CSV.parse(data, headers: true)
 
     rows.each do |row|
       attrs = row.to_hash

--- a/lib/tasks/temp/migrate_rando.rake
+++ b/lib/tasks/temp/migrate_rando.rake
@@ -24,4 +24,8 @@ task migrate_rando: :environment do
 
     puts "imported #{klass}"
   end
+
+  ActiveRecord::Base.connection.tables.each do |t|
+    ActiveRecord::Base.connection.reset_pk_sequence!(t)
+  end
 end


### PR DESCRIPTION
This PR improves the rando migration task so that it'll pull data from the web and also leave the database in sync so that new records won't try to use existing ids.