### PR TITLE
Guard against nil titles

### DIFF
--- a/Procfile.dev
+++ b/Procfile.dev
@@ -1,0 +1,3 @@
+web: PORT=3007 bundle exec puma
+worker: bundle exec sidekiq -c 1
+webpacker: ./bin/webpack-dev-server

--- a/app/models/entry.rb
+++ b/app/models/entry.rb
@@ -11,7 +11,8 @@ class Entry
   end
 
   def title
-    CGI.unescapeHTML @data['title']
+    data_title = @data['title'] || ''
+    CGI.unescapeHTML data_title
   end
 
   def feed_title

--- a/config/webpacker.yml
+++ b/config/webpacker.yml
@@ -36,8 +36,8 @@ development:
   dev_server:
     https: false
     host: localhost
-    port: 3035
-    public: localhost:3035
+    port: 3008
+    public: localhost:3008
     hmr: false
     # Inline should be set to true if using HMR
     inline: true


### PR DESCRIPTION
I had a bug where one of the entries coming back had a nil title and so I couldn't even render the page. All I'm doing here is guarding against this case and falling back to an empty title.