### PR TITLE
Ensure entry sort

### DIFF
--- a/app/javascript/shared/dum_reader/Reader.js
+++ b/app/javascript/shared/dum_reader/Reader.js
@@ -1,6 +1,16 @@
 import Entry from "shared/dum_reader/Entry"
 import Router from "shared/dum_reader/Router"
 
+const sortByDate = (lhsEntry, rhsEntry) => {
+  if (lhsEntry.date < rhsEntry.date) {
+    return -1
+  } else if (lhsEntry.date > rhsEntry.date) {
+    return 1
+  } else {
+    return 0
+  }
+}
+
 class Reader {
   constructor() {
     this.router = new Router()
@@ -54,9 +64,15 @@ class Reader {
     unread_entries, // eslint-disable-line camelcase
     timestamp
   }) => {
-    const archivedEntries = archived_entries.map(data => new Entry(data))
-    const savedEntries = saved_entries.map(data => new Entry(data))
-    const unreadEntries = unread_entries.map(data => new Entry(data))
+    const archivedEntries = archived_entries
+      .map(data => new Entry(data))
+      .sort(sortByDate)
+    const savedEntries = saved_entries
+      .map(data => new Entry(data))
+      .sort(sortByDate)
+    const unreadEntries = unread_entries
+      .map(data => new Entry(data))
+      .sort(sortByDate)
 
     this.resetState(archivedEntries, savedEntries, unreadEntries, timestamp)
     this.refreshCallback()


### PR DESCRIPTION
Prior to this commit it was possible for entries to list in a random order, but it didn't always happen. I could never quite figure out what was causing the issue but rather than worry about that, this PR simply sorts them client-side.

Note: it's possible that this sorting by the string date of the entry will produce some wacky results. A better approach would be to send the date as an integer from the server to the client and then do an alpha sort on that, but it didn't seem worth taking that step.