### PR TITLE
Convert artsy pr list to hooks

### DIFF
--- a/app/javascript/apps/ArtsyPullRequests/ArtsyPullRequests.spec.tsx
+++ b/app/javascript/apps/ArtsyPullRequests/ArtsyPullRequests.spec.tsx
@@ -1,0 +1,75 @@
+import React from "react"
+import { act } from "react-dom/test-utils"
+import { mount } from "enzyme"
+import { ArtsyPullRequests, ArtsyPullRequestsProps } from "./"
+import { PullList } from "./components/PullList"
+import { PullItem } from "./components/PullItem"
+
+const pullRequest = {
+  color: "black",
+  id: "123",
+  repo: "monolithium",
+  title: "Initial commit",
+  url: "https://github.com/jonallured/monolithium",
+  username: "jonallured"
+}
+
+const defaultProps: ArtsyPullRequestsProps = {
+  pullRequests: [],
+  startListening: jest.fn(),
+  stopListening: jest.fn()
+}
+
+describe("rendering", () => {
+  it("renders no items with there are no pull requests", () => {
+    const props: ArtsyPullRequestsProps = {
+      ...defaultProps,
+      pullRequests: []
+    }
+
+    const wrapper = mount(<ArtsyPullRequests {...props} />)
+
+    expect(wrapper.find(PullList)).toHaveLength(1)
+    expect(wrapper.find(PullItem)).toHaveLength(0)
+  })
+
+  it("renders 1 item with there is 1 pull request", () => {
+    const props: ArtsyPullRequestsProps = {
+      ...defaultProps,
+      pullRequests: [pullRequest]
+    }
+
+    const wrapper = mount(<ArtsyPullRequests {...props} />)
+
+    expect(wrapper.find(PullItem)).toHaveLength(1)
+  })
+
+  it("renders new pull requests", () => {
+    let handleNewPullRequest
+
+    const mockStartListening = (handler): void => {
+      handleNewPullRequest = handler
+    }
+
+    const props: ArtsyPullRequestsProps = {
+      ...defaultProps,
+      pullRequests: [],
+      startListening: mockStartListening
+    }
+
+    const wrapper = mount(<ArtsyPullRequests {...props} />)
+
+    expect(wrapper.find(PullItem)).toHaveLength(0)
+
+    act(() => {
+      const event = {
+        detail: pullRequest
+      }
+      handleNewPullRequest(event)
+    })
+
+    wrapper.update()
+
+    expect(wrapper.find(PullItem)).toHaveLength(1)
+  })
+})

--- a/app/javascript/apps/ArtsyPullRequests/ArtsyPullRequests.tsx
+++ b/app/javascript/apps/ArtsyPullRequests/ArtsyPullRequests.tsx
@@ -1,4 +1,4 @@
-import React from "react"
+import React, { useEffect, useState } from "react"
 import styled from "styled-components"
 
 const PRList = styled.ul`
@@ -22,34 +22,36 @@ const PRList = styled.ul`
   }
 `
 
-export class ArtsyPullRequests extends React.Component {
-  state = { pullRequests: [] }
+export const ArtsyPullRequests: React.FC = () => {
+  const [pullRequests, setPullRequests] = useState([])
 
-  componentDidMount(): void {
-    const root = document.getElementById("root")
-    root.addEventListener("NewPullRequest", this.handleNewPullRequest)
-  }
-
-  handleNewPullRequest = (e): void => {
+  const handleNewPullRequest = (e): void => {
     const newPullRequest = e.detail
-    this.setState({
-      pullRequests: [newPullRequest, ...this.state.pullRequests]
-    })
+
+    setPullRequests(currentPullRequests => [
+      newPullRequest,
+      ...currentPullRequests
+    ])
   }
 
-  computePullRequestTags = (): React.ReactNode => {
-    return this.state.pullRequests.map(pullRequest => (
+  useEffect(() => {
+    const root = document.getElementById("root")
+    root.addEventListener("NewPullRequest", handleNewPullRequest)
+
+    return (): void => {
+      root.removeEventListener("NewPullRequest", handleNewPullRequest)
+    }
+  }, [])
+
+  const pullRequestTags = pullRequests.map(pullRequest => {
+    return (
       <li key={pullRequest.id} style={{ backgroundColor: pullRequest.color }}>
         <a href={pullRequest.url} target="_blank" rel="noopener noreferrer">
           {pullRequest.title} by @{pullRequest.username} on {pullRequest.repo}
         </a>
       </li>
-    ))
-  }
+    )
+  })
 
-  render(): React.ReactNode {
-    const pullRequestTags = this.computePullRequestTags()
-
-    return <PRList>{pullRequestTags}</PRList>
-  }
+  return <PRList>{pullRequestTags}</PRList>
 }

--- a/app/javascript/apps/ArtsyPullRequests/ArtsyPullRequests.tsx
+++ b/app/javascript/apps/ArtsyPullRequests/ArtsyPullRequests.tsx
@@ -1,26 +1,6 @@
 import React, { useEffect, useState } from "react"
-import styled from "styled-components"
-
-const PRList = styled.ul`
-  font-size: 40px;
-  line-height: 1.6em;
-  list-style: none;
-  margin: 0;
-  padding: 0;
-
-  li {
-    padding: 10px 20px;
-  }
-
-  a {
-    color: black;
-    text-decoration: none;
-
-    &:hover {
-      text-decoration: underline;
-    }
-  }
-`
+import { PullList } from "./components/PullList"
+import { PullItem } from "./components/PullItem"
 
 export const ArtsyPullRequests: React.FC = () => {
   const [pullRequests, setPullRequests] = useState([])
@@ -43,15 +23,9 @@ export const ArtsyPullRequests: React.FC = () => {
     }
   }, [])
 
-  const pullRequestTags = pullRequests.map(pullRequest => {
-    return (
-      <li key={pullRequest.id} style={{ backgroundColor: pullRequest.color }}>
-        <a href={pullRequest.url} target="_blank" rel="noopener noreferrer">
-          {pullRequest.title} by @{pullRequest.username} on {pullRequest.repo}
-        </a>
-      </li>
-    )
+  const pullItems = pullRequests.map((pullRequest, i) => {
+    return <PullItem key={i} pullRequest={pullRequest} />
   })
 
-  return <PRList>{pullRequestTags}</PRList>
+  return <PullList>{pullItems}</PullList>
 }

--- a/app/javascript/apps/ArtsyPullRequests/ArtsyPullRequests.tsx
+++ b/app/javascript/apps/ArtsyPullRequests/ArtsyPullRequests.tsx
@@ -1,8 +1,13 @@
 import React, { useEffect, useState } from "react"
 import { PullList } from "./components/PullList"
-import { PullItem } from "./components/PullItem"
 
-export const ArtsyPullRequests: React.FC = () => {
+export interface ArtsyPullRequestsProps {
+  startListening: (handler) => void
+  stopListening: (handler) => void
+}
+
+export const ArtsyPullRequests: React.FC<ArtsyPullRequestsProps> = props => {
+  const { startListening, stopListening } = props
   const [pullRequests, setPullRequests] = useState([])
 
   const handleNewPullRequest = (e): void => {
@@ -15,17 +20,12 @@ export const ArtsyPullRequests: React.FC = () => {
   }
 
   useEffect(() => {
-    const root = document.getElementById("root")
-    root.addEventListener("NewPullRequest", handleNewPullRequest)
+    startListening(handleNewPullRequest)
 
     return (): void => {
-      root.removeEventListener("NewPullRequest", handleNewPullRequest)
+      stopListening(handleNewPullRequest)
     }
   }, [])
 
-  const pullItems = pullRequests.map((pullRequest, i) => {
-    return <PullItem key={i} pullRequest={pullRequest} />
-  })
-
-  return <PullList>{pullItems}</PullList>
+  return <PullList pullRequests={pullRequests} />
 }

--- a/app/javascript/apps/ArtsyPullRequests/ArtsyPullRequests.tsx
+++ b/app/javascript/apps/ArtsyPullRequests/ArtsyPullRequests.tsx
@@ -1,14 +1,24 @@
 import React, { useEffect, useState } from "react"
 import { PullList } from "./components/PullList"
 
+export interface PullRequest {
+  color: string
+  id: string
+  repo: string
+  title: string
+  url: string
+  username: string
+}
+
 export interface ArtsyPullRequestsProps {
+  pullRequests: PullRequest[]
   startListening: (handler) => void
   stopListening: (handler) => void
 }
 
 export const ArtsyPullRequests: React.FC<ArtsyPullRequestsProps> = props => {
   const { startListening, stopListening } = props
-  const [pullRequests, setPullRequests] = useState([])
+  const [pullRequests, setPullRequests] = useState(props.pullRequests)
 
   const handleNewPullRequest = (e): void => {
     const newPullRequest = e.detail

--- a/app/javascript/apps/ArtsyPullRequests/components/PullItem/PullItem.tsx
+++ b/app/javascript/apps/ArtsyPullRequests/components/PullItem/PullItem.tsx
@@ -1,6 +1,6 @@
 import React from "react"
 
-interface PullRequest {
+export interface PullRequest {
   color: string
   id: string
   repo: string

--- a/app/javascript/apps/ArtsyPullRequests/components/PullItem/PullItem.tsx
+++ b/app/javascript/apps/ArtsyPullRequests/components/PullItem/PullItem.tsx
@@ -1,0 +1,27 @@
+import React from "react"
+
+interface PullRequest {
+  color: string
+  id: string
+  repo: string
+  title: string
+  url: string
+  username: string
+}
+
+interface PullItemProps {
+  pullRequest: PullRequest
+}
+
+export const PullItem: React.FC<PullItemProps> = props => {
+  const { pullRequest } = props
+  const content = `${pullRequest.title} by @${pullRequest.username} on ${pullRequest.repo}`
+
+  return (
+    <li style={{ backgroundColor: pullRequest.color }}>
+      <a href={pullRequest.url} target="_blank" rel="noopener noreferrer">
+        {content}
+      </a>
+    </li>
+  )
+}

--- a/app/javascript/apps/ArtsyPullRequests/components/PullItem/PullItem.tsx
+++ b/app/javascript/apps/ArtsyPullRequests/components/PullItem/PullItem.tsx
@@ -1,5 +1,6 @@
 import React from "react"
 import styled from "styled-components"
+import { PullRequest } from "../../ArtsyPullRequests"
 
 interface ItemProps {
   backgroundColor: string
@@ -18,15 +19,6 @@ const Item = styled.li<ItemProps>`
     }
   }
 `
-
-export interface PullRequest {
-  color: string
-  id: string
-  repo: string
-  title: string
-  url: string
-  username: string
-}
 
 interface PullItemProps {
   pullRequest: PullRequest

--- a/app/javascript/apps/ArtsyPullRequests/components/PullItem/PullItem.tsx
+++ b/app/javascript/apps/ArtsyPullRequests/components/PullItem/PullItem.tsx
@@ -1,4 +1,23 @@
 import React from "react"
+import styled from "styled-components"
+
+interface ItemProps {
+  backgroundColor: string
+}
+
+const Item = styled.li<ItemProps>`
+  background-color: ${(props): string => props.backgroundColor};
+  padding: 10px 20px;
+
+  a {
+    color: black;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+`
 
 export interface PullRequest {
   color: string
@@ -18,10 +37,10 @@ export const PullItem: React.FC<PullItemProps> = props => {
   const content = `${pullRequest.title} by @${pullRequest.username} on ${pullRequest.repo}`
 
   return (
-    <li style={{ backgroundColor: pullRequest.color }}>
+    <Item backgroundColor={pullRequest.color}>
       <a href={pullRequest.url} target="_blank" rel="noopener noreferrer">
         {content}
       </a>
-    </li>
+    </Item>
   )
 }

--- a/app/javascript/apps/ArtsyPullRequests/components/PullItem/index.ts
+++ b/app/javascript/apps/ArtsyPullRequests/components/PullItem/index.ts
@@ -1,0 +1,1 @@
+export * from "./PullItem"

--- a/app/javascript/apps/ArtsyPullRequests/components/PullList/PullList.tsx
+++ b/app/javascript/apps/ArtsyPullRequests/components/PullList/PullList.tsx
@@ -1,0 +1,22 @@
+import styled from "styled-components"
+
+export const PullList = styled.ul`
+  font-size: 40px;
+  line-height: 1.6em;
+  list-style: none;
+  margin: 0;
+  padding: 0;
+
+  li {
+    padding: 10px 20px;
+  }
+
+  a {
+    color: black;
+    text-decoration: none;
+
+    &:hover {
+      text-decoration: underline;
+    }
+  }
+`

--- a/app/javascript/apps/ArtsyPullRequests/components/PullList/PullList.tsx
+++ b/app/javascript/apps/ArtsyPullRequests/components/PullList/PullList.tsx
@@ -8,19 +8,6 @@ const List = styled.ul`
   list-style: none;
   margin: 0;
   padding: 0;
-
-  li {
-    padding: 10px 20px;
-  }
-
-  a {
-    color: black;
-    text-decoration: none;
-
-    &:hover {
-      text-decoration: underline;
-    }
-  }
 `
 
 interface PullListProps {

--- a/app/javascript/apps/ArtsyPullRequests/components/PullList/PullList.tsx
+++ b/app/javascript/apps/ArtsyPullRequests/components/PullList/PullList.tsx
@@ -1,6 +1,8 @@
+import React from "react"
 import styled from "styled-components"
+import { PullItem, PullRequest } from "../PullItem"
 
-export const PullList = styled.ul`
+const List = styled.ul`
   font-size: 40px;
   line-height: 1.6em;
   list-style: none;
@@ -20,3 +22,17 @@ export const PullList = styled.ul`
     }
   }
 `
+
+interface PullListProps {
+  pullRequests: PullRequest[]
+}
+
+export const PullList: React.FC<PullListProps> = props => {
+  const { pullRequests } = props
+
+  const items = pullRequests.map((pullRequest, i) => {
+    return <PullItem key={i} pullRequest={pullRequest} />
+  })
+
+  return <List>{items}</List>
+}

--- a/app/javascript/apps/ArtsyPullRequests/components/PullList/PullList.tsx
+++ b/app/javascript/apps/ArtsyPullRequests/components/PullList/PullList.tsx
@@ -1,6 +1,7 @@
 import React from "react"
 import styled from "styled-components"
-import { PullItem, PullRequest } from "../PullItem"
+import { PullRequest } from "../../ArtsyPullRequests"
+import { PullItem } from "../PullItem"
 
 const List = styled.ul`
   font-size: 40px;

--- a/app/javascript/apps/ArtsyPullRequests/components/PullList/index.ts
+++ b/app/javascript/apps/ArtsyPullRequests/components/PullList/index.ts
@@ -1,0 +1,1 @@
+export * from "./PullList"

--- a/app/javascript/packs/artsy_pull_requests.tsx
+++ b/app/javascript/packs/artsy_pull_requests.tsx
@@ -1,7 +1,27 @@
 import React from "react"
 import ReactDOM from "react-dom"
-import { ArtsyPullRequests } from "../apps/ArtsyPullRequests"
+import {
+  ArtsyPullRequests,
+  ArtsyPullRequestsProps
+} from "../apps/ArtsyPullRequests"
+
+const eventName = "NewPullRequest"
 
 document.addEventListener("DOMContentLoaded", () => {
-  ReactDOM.render(<ArtsyPullRequests />, document.getElementById("root"))
+  const root = document.getElementById("root")
+
+  const startListening = (handler): void => {
+    root.addEventListener(eventName, handler)
+  }
+
+  const stopListening = (handler): void => {
+    root.removeEventListener(eventName, handler)
+  }
+
+  const props: ArtsyPullRequestsProps = {
+    startListening,
+    stopListening
+  }
+
+  ReactDOM.render(<ArtsyPullRequests {...props} />, root)
 })

--- a/app/javascript/packs/artsy_pull_requests.tsx
+++ b/app/javascript/packs/artsy_pull_requests.tsx
@@ -19,6 +19,7 @@ document.addEventListener("DOMContentLoaded", () => {
   }
 
   const props: ArtsyPullRequestsProps = {
+    pullRequests: [],
     startListening,
     stopListening
   }

--- a/app/javascript/testing/setup.ts
+++ b/app/javascript/testing/setup.ts
@@ -1,0 +1,5 @@
+import { configure } from "enzyme"
+import Adapter from "enzyme-adapter-react-16"
+
+const adapter = new Adapter()
+configure({ adapter })

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
     "prop-types": "^15.6.2",
     "react": "^16.5.2",
     "react-dom": "^16.5.2",
-    "styled-components": "^3.4.9",
+    "styled-components": "^5.0.1",
     "ts-loader": "^6.2.1",
     "typescript": "^3.7.5"
   },

--- a/package.json
+++ b/package.json
@@ -52,6 +52,7 @@
     "prettier": "prettier --write 'app/javascript/**/*.{js,jsx,ts,tsx}'",
     "prettier-check": "prettier --check 'app/javascript/**/*.{js,jsx,ts,tsx}'",
     "test": "jest",
+    "test:watch": "jest --watch",
     "type-check": "tsc --pretty --noEmit"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -49,7 +49,7 @@
     lodash "^4.17.13"
     source-map "^0.5.0"
 
-"@babel/helper-annotate-as-pure@^7.8.3":
+"@babel/helper-annotate-as-pure@^7.0.0", "@babel/helper-annotate-as-pure@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.8.3.tgz#60bc0bc657f63a0924ff9a4b4a0b24a13cf4deee"
   integrity sha512-6o+mJrZBxOoEX77Ezv9zwW7WV8DdluouRKNY/IR5u/YTMuKHgugHOzYWlYvYLpLA9nPsQCAAASpCIbjI9Mv+Uw==
@@ -159,7 +159,7 @@
   dependencies:
     "@babel/types" "^7.8.3"
 
-"@babel/helper-module-imports@^7.8.3":
+"@babel/helper-module-imports@^7.0.0", "@babel/helper-module-imports@^7.8.3":
   version "7.8.3"
   resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.8.3.tgz#7fe39589b39c016331b6b8c3f441e8f0b1419498"
   integrity sha512-R0Bx3jippsbAEtzkpZ/6FIiuzOURPcMjHp+Z6xPe6DtApDJx+w7UYyOLanZqO8+wKR9G10s/FmHXvxaMd9s6Kg==
@@ -810,7 +810,7 @@
     "@babel/parser" "^7.8.3"
     "@babel/types" "^7.8.3"
 
-"@babel/traverse@^7.1.0", "@babel/traverse@^7.7.4", "@babel/traverse@^7.8.3", "@babel/traverse@^7.8.4":
+"@babel/traverse@^7.1.0", "@babel/traverse@^7.4.5", "@babel/traverse@^7.7.4", "@babel/traverse@^7.8.3", "@babel/traverse@^7.8.4":
   version "7.8.4"
   resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.8.4.tgz#f0845822365f9d5b0e312ed3959d3f827f869e3c"
   integrity sha512-NGLJPZwnVEyBPLI+bl9y9aSnxMhsKz42so7ApAv9D+b4vAFPpY013FTS9LdKxcABoIYFU52HcYga1pPlx454mg==
@@ -851,6 +851,28 @@
   version "1.4.0"
   resolved "https://registry.yarnpkg.com/@csstools/convert-colors/-/convert-colors-1.4.0.tgz#ad495dc41b12e75d588c6db8b9834f08fa131eb7"
   integrity sha512-5a6wqoJV/xEdbRNKVo6I4hO3VjyDq//8q2f9I6PBAvMesJHFauXDorcNCsr9RzvsZnaWi5NYCcfyqP1QeFHFbw==
+
+"@emotion/is-prop-valid@^0.8.3":
+  version "0.8.6"
+  resolved "https://registry.yarnpkg.com/@emotion/is-prop-valid/-/is-prop-valid-0.8.6.tgz#4757646f0a58e9dec614c47c838e7147d88c263c"
+  integrity sha512-mnZMho3Sq8BfzkYYRVc8ilQTnc8U02Ytp6J1AwM6taQStZ3AhsEJBX2LzhA/LJirNCwM2VtHL3VFIZ+sNJUgUQ==
+  dependencies:
+    "@emotion/memoize" "0.7.4"
+
+"@emotion/memoize@0.7.4":
+  version "0.7.4"
+  resolved "https://registry.yarnpkg.com/@emotion/memoize/-/memoize-0.7.4.tgz#19bf0f5af19149111c40d98bb0cf82119f5d9eeb"
+  integrity sha512-Ja/Vfqe3HpuzRsG1oBtWTHk2PGZ7GR+2Vz5iYGelAw8dx32K0y7PjVuxK6z1nMpZOqAFsRUPCkK1YjJ56qJlgw==
+
+"@emotion/stylis@^0.8.4":
+  version "0.8.5"
+  resolved "https://registry.yarnpkg.com/@emotion/stylis/-/stylis-0.8.5.tgz#deacb389bd6ee77d1e7fcaccce9e16c5c7e78e04"
+  integrity sha512-h6KtPihKFn3T9fuIrwvXXUOwlx3rfUvfZIcP5a6rh8Y7zjE3O06hT5Ss4S/YI1AYhuZ1kjaE/5EaOOI2NqSylQ==
+
+"@emotion/unitless@^0.7.4":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@emotion/unitless/-/unitless-0.7.5.tgz#77211291c1900a700b8a78cfafda3160d76949ed"
+  integrity sha512-OWORNpfjMsSSUBVrRBVGECkhWcULOAJz9ZW8uK9qgxD+87M7jHRcvh/A96XXNhXTLmKcoYSQtBEX7lHMO7YRwg==
 
 "@istanbuljs/load-nyc-config@^1.0.0":
   version "1.0.0"
@@ -1698,11 +1720,6 @@ array.prototype.flat@^1.2.3:
     define-properties "^1.1.3"
     es-abstract "^1.17.0-next.1"
 
-asap@~2.0.3:
-  version "2.0.6"
-  resolved "https://registry.yarnpkg.com/asap/-/asap-2.0.6.tgz#e50347611d7e690943208bbdafebcbc2fb866d46"
-  integrity sha1-5QNHYR1+aQlDIIu9r+vLwvuGbUY=
-
 asn1.js@^4.0.0:
   version "4.10.1"
   resolved "https://registry.yarnpkg.com/asn1.js/-/asn1.js-4.10.1.tgz#b9c2bf5805f1e64aadeed6df3a2bfafb5a73f5a0"
@@ -1864,6 +1881,21 @@ babel-plugin-module-resolver@^4.0.0:
     pkg-up "^3.1.0"
     reselect "^4.0.0"
     resolve "^1.13.1"
+
+"babel-plugin-styled-components@>= 1":
+  version "1.10.7"
+  resolved "https://registry.yarnpkg.com/babel-plugin-styled-components/-/babel-plugin-styled-components-1.10.7.tgz#3494e77914e9989b33cc2d7b3b29527a949d635c"
+  integrity sha512-MBMHGcIA22996n9hZRf/UJLVVgkEOITuR2SvjHLb5dSTUyR4ZRGn+ngITapes36FI3WLxZHfRhkA1ffHxihOrg==
+  dependencies:
+    "@babel/helper-annotate-as-pure" "^7.0.0"
+    "@babel/helper-module-imports" "^7.0.0"
+    babel-plugin-syntax-jsx "^6.18.0"
+    lodash "^4.17.11"
+
+babel-plugin-syntax-jsx@^6.18.0:
+  version "6.18.0"
+  resolved "https://registry.yarnpkg.com/babel-plugin-syntax-jsx/-/babel-plugin-syntax-jsx-6.18.0.tgz#0af32a9a6e13ca7a3fd5069e62d7b0f58d0d8946"
+  integrity sha1-CvMqmm4Tyno/1QaeYtew9Y0NiUY=
 
 babel-preset-jest@^25.1.0:
   version "25.1.0"
@@ -2122,14 +2154,6 @@ buffer@^4.3.0:
     base64-js "^1.0.2"
     ieee754 "^1.1.4"
     isarray "^1.0.0"
-
-buffer@^5.0.3:
-  version "5.4.3"
-  resolved "https://registry.yarnpkg.com/buffer/-/buffer-5.4.3.tgz#3fbc9c69eb713d323e3fc1a895eee0710c072115"
-  integrity sha512-zvj65TkFeIt3i6aj5bIvJDzjjQQGs4o/sNoezg1F1kYap9Nu2jcUdpwzRSJTHMMzG0H7bZkn4rNQpImhuxWX2A==
-  dependencies:
-    base64-js "^1.0.2"
-    ieee754 "^1.1.4"
 
 builtin-status-codes@^3.0.0:
   version "3.0.0"
@@ -2666,11 +2690,6 @@ core-js-compat@^3.6.2:
     browserslist "^4.8.3"
     semver "7.0.0"
 
-core-js@^1.0.0:
-  version "1.2.7"
-  resolved "https://registry.yarnpkg.com/core-js/-/core-js-1.2.7.tgz#652294c14651db28fa93bd2d5ff2983a4f08c636"
-  integrity sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY=
-
 core-js@^3.4.0:
   version "3.6.4"
   resolved "https://registry.yarnpkg.com/core-js/-/core-js-3.6.4.tgz#440a83536b458114b9cb2ac1580ba377dc470647"
@@ -2861,14 +2880,14 @@ css-select@~1.2.0:
     domutils "1.5.1"
     nth-check "~1.0.1"
 
-css-to-react-native@^2.0.3:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-2.3.2.tgz#e75e2f8f7aa385b4c3611c52b074b70a002f2e7d"
-  integrity sha512-VOFaeZA053BqvvvqIA8c9n0+9vFppVBAHCp6JgFTtTMU3Mzi+XnelJ9XC9ul3BqFzZyQ5N+H0SnwsWT2Ebchxw==
+css-to-react-native@^3.0.0:
+  version "3.0.0"
+  resolved "https://registry.yarnpkg.com/css-to-react-native/-/css-to-react-native-3.0.0.tgz#62dbe678072a824a689bcfee011fc96e02a7d756"
+  integrity sha512-Ro1yETZA813eoyUp2GDBhG2j+YggidUmzO1/v9eYBKR2EHVEniE2MI/NqpTQ954BMpTPZFsGNPm46qFB9dpaPQ==
   dependencies:
     camelize "^1.0.0"
     css-color-keywords "^1.0.0"
-    postcss-value-parser "^3.3.0"
+    postcss-value-parser "^4.0.2"
 
 css-tree@1.0.0-alpha.37:
   version "1.0.0-alpha.37"
@@ -3355,13 +3374,6 @@ encodeurl@~1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/encodeurl/-/encodeurl-1.0.2.tgz#ad3ff4c86ec2d029322f5a02c3a9a606c95b3f59"
   integrity sha1-rT/0yG7C0CkyL1oCw6mmBslbP1k=
-
-encoding@^0.1.11:
-  version "0.1.12"
-  resolved "https://registry.yarnpkg.com/encoding/-/encoding-0.1.12.tgz#538b66f3ee62cd1ab51ec323829d1f9480c74beb"
-  integrity sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=
-  dependencies:
-    iconv-lite "~0.4.13"
 
 end-of-stream@^1.0.0, end-of-stream@^1.1.0:
   version "1.4.4"
@@ -3881,19 +3893,6 @@ fb-watchman@^2.0.0:
   dependencies:
     bser "2.1.1"
 
-fbjs@^0.8.16:
-  version "0.8.17"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.17.tgz#c4d598ead6949112653d6588b01a5cdcd9f90fdd"
-  integrity sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.18"
-
 figgy-pudding@^3.5.1:
   version "3.5.1"
   resolved "https://registry.yarnpkg.com/figgy-pudding/-/figgy-pudding-3.5.1.tgz#862470112901c727a0e495a80744bd5baa1d6790"
@@ -4364,11 +4363,6 @@ has-ansi@^2.0.0:
   dependencies:
     ansi-regex "^2.0.0"
 
-has-flag@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-1.0.0.tgz#9d9e793165ce017a00f00418c43f942a7b1d11fa"
-  integrity sha1-nZ55MWXOAXoA8AQYxD+UKnsdEfo=
-
 has-flag@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/has-flag/-/has-flag-3.0.0.tgz#b5d454dc2199ae225699f3467e5a07f3b955bafd"
@@ -4457,10 +4451,12 @@ hmac-drbg@^1.0.0:
     minimalistic-assert "^1.0.0"
     minimalistic-crypto-utils "^1.0.1"
 
-hoist-non-react-statics@^2.5.0:
-  version "2.5.5"
-  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-2.5.5.tgz#c5903cf409c0dfd908f388e619d86b9c1174cb47"
-  integrity sha512-rqcy4pJo55FTTLWt+bU8ukscqHeE/e9KWvsOW2b/a3afxQZhwkQdT1rPPCJ0rYXdj4vNcasY8zHTH+jF/qStxw==
+hoist-non-react-statics@^3.0.0:
+  version "3.3.2"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.3.2.tgz#ece0acaf71d62c2969c2ec59feff42a4b1a85b45"
+  integrity sha512-/gGivxi8JPKWNm/W0jSmzcMPpfpPLc3dY/6GxhX2hQ9iGj3aDfklV4ET7NjKpSinLpJ5vafa9iiGIEZg10SfBw==
+  dependencies:
+    react-is "^16.7.0"
 
 homedir-polyfill@^1.0.1:
   version "1.0.3"
@@ -4615,7 +4611,7 @@ human-signals@^1.1.1:
   resolved "https://registry.yarnpkg.com/human-signals/-/human-signals-1.1.1.tgz#c5b1cd14f50aeae09ab6c59fe63ba3395fe4dfa3"
   integrity sha512-SEQu7vl8KjNL2eoGBLF3+wAjpsNfA9XMlXAYj/3EdaNfAlxKthD1xjEQfGOUhllCGGJVNY34bRr6lPINhNjyZw==
 
-iconv-lite@0.4.24, iconv-lite@^0.4.24, iconv-lite@~0.4.13:
+iconv-lite@0.4.24, iconv-lite@^0.4.24:
   version "0.4.24"
   resolved "https://registry.yarnpkg.com/iconv-lite/-/iconv-lite-0.4.24.tgz#2022b4b25fbddc21d2f524974a474aafe733908b"
   integrity sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==
@@ -5080,7 +5076,7 @@ is-resolvable@^1.0.0:
   resolved "https://registry.yarnpkg.com/is-resolvable/-/is-resolvable-1.1.0.tgz#fb18f87ce1feb925169c9a407c19318a3206ed88"
   integrity sha512-qgDYXFSR5WvEfuS5dMj6oTMEbrrSaM0CrFk2Yiq/gXnBvD9pMa2jGXxyhGLfvhZpuMZe18CJpFxAt3CRs42NMg==
 
-is-stream@^1.0.1, is-stream@^1.1.0:
+is-stream@^1.1.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
   integrity sha1-EtSj3U5o4Lec6428hBc66A2RykQ=
@@ -5160,14 +5156,6 @@ isobject@^3.0.0, isobject@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/isobject/-/isobject-3.0.1.tgz#4e431e92b11a9731636aa1f9c8d1ccbcfdab78df"
   integrity sha1-TkMekrEalzFjaqH5yNHMvP2reN8=
-
-isomorphic-fetch@^2.1.1:
-  version "2.2.1"
-  resolved "https://registry.yarnpkg.com/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz#611ae1acf14f5e81f729507472819fe9733558a9"
-  integrity sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=
-  dependencies:
-    node-fetch "^1.0.1"
-    whatwg-fetch ">=0.10.0"
 
 isstream@~0.1.2:
   version "0.1.2"
@@ -6312,14 +6300,6 @@ nice-try@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/nice-try/-/nice-try-1.0.5.tgz#a3378a7696ce7d223e88fc9b764bd7ef1089e366"
   integrity sha512-1nh45deeb5olNY7eX82BkPO7SSxR5SSYJiPTrTdFUVYwAl8CKMA5N9PjTYkHiRjisVcxcQ1HXdLhx2qxxJzLNQ==
-
-node-fetch@^1.0.1:
-  version "1.7.3"
-  resolved "https://registry.yarnpkg.com/node-fetch/-/node-fetch-1.7.3.tgz#980f6f72d85211a5347c6b2bc18c5b84c3eb47ef"
-  integrity sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==
-  dependencies:
-    encoding "^0.1.11"
-    is-stream "^1.0.1"
 
 node-forge@0.9.0:
   version "0.9.0"
@@ -7664,7 +7644,7 @@ postcss-unique-selectors@^4.0.1:
     postcss "^7.0.0"
     uniqs "^2.0.0"
 
-postcss-value-parser@^3.0.0, postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.0, postcss-value-parser@^3.3.1:
+postcss-value-parser@^3.0.0, postcss-value-parser@^3.2.3, postcss-value-parser@^3.3.1:
   version "3.3.1"
   resolved "https://registry.yarnpkg.com/postcss-value-parser/-/postcss-value-parser-3.3.1.tgz#9ff822547e2893213cf1c30efa51ac5fd1ba8281"
   integrity sha512-pISE66AbVkp4fDQ7VHBwRNXzAAKJjw4Vw7nWI/+Q3vuly7SNfgYXvm6i5IgFylHGK5sP/xHAbB7N49OS4gWNyQ==
@@ -7742,13 +7722,6 @@ promise-inflight@^1.0.1:
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
   integrity sha1-mEcocL8igTL8vdhoEputEsPAKeM=
 
-promise@^7.1.1:
-  version "7.3.1"
-  resolved "https://registry.yarnpkg.com/promise/-/promise-7.3.1.tgz#064b72602b18f90f29192b8b1bc418ffd1ebd3bf"
-  integrity sha512-nolQXZ/4L+bP/UGlkfaIujX9BKxGwmQ9OT4mOt5yvy8iK1h3wqTEJCijzGANTCCl9nWjY41juyAn2K3Q1hLLTg==
-  dependencies:
-    asap "~2.0.3"
-
 prompts@^2.0.1:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/prompts/-/prompts-2.3.0.tgz#a444e968fa4cc7e86689a74050685ac8006c4cc4"
@@ -7766,7 +7739,7 @@ prop-types-exact@^1.2.0:
     object.assign "^4.1.0"
     reflect.ownkeys "^0.2.0"
 
-prop-types@^15.5.4, prop-types@^15.6.2, prop-types@^15.7.2:
+prop-types@^15.6.2, prop-types@^15.7.2:
   version "15.7.2"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.7.2.tgz#52c41e75b8c87e72b9d9360e0206b99dcbffa6c5"
   integrity sha512-8QQikdH7//R2vurIJSutZ1smHYTcLpRWEOlHnzcWHmBYrOGUysKwSsrC89BCiFj3CbrfJ/nXFdJepOVrY1GCHQ==
@@ -7948,7 +7921,7 @@ react-dom@^16.5.2:
     prop-types "^15.6.2"
     scheduler "^0.18.0"
 
-react-is@^16.12.0, react-is@^16.3.1, react-is@^16.8.1, react-is@^16.8.6, react-is@^16.9.0:
+react-is@^16.12.0, react-is@^16.7.0, react-is@^16.8.1, react-is@^16.8.6, react-is@^16.9.0:
   version "16.12.0"
   resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.12.0.tgz#2cc0fe0fba742d97fd527c42a13bec4eeb06241c"
   integrity sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q==
@@ -8557,7 +8530,7 @@ set-value@^2.0.0, set-value@^2.0.1:
     is-plain-object "^2.0.3"
     split-string "^3.0.1"
 
-setimmediate@^1.0.4, setimmediate@^1.0.5:
+setimmediate@^1.0.4:
   version "1.0.5"
   resolved "https://registry.yarnpkg.com/setimmediate/-/setimmediate-1.0.5.tgz#290cbb232e306942d7d7ea9b83732ab7856f8285"
   integrity sha1-KQy7Iy4waULX1+qbg3Mqt4VvgoU=
@@ -8586,6 +8559,11 @@ shallow-clone@^3.0.0:
   integrity sha512-/6KqX+GVUdqPuPPd2LxDDxzX6CAbjJehAAOKlNpqqUpAqPM6HeL8f+o3a+JsyGjn2lv0WY8UsTgUJjU9Ok55NA==
   dependencies:
     kind-of "^6.0.2"
+
+shallowequal@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/shallowequal/-/shallowequal-1.1.0.tgz#188d521de95b9087404fd4dcb68b13df0ae4e7f8"
+  integrity sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==
 
 shebang-command@^1.2.0:
   version "1.2.0"
@@ -9090,20 +9068,21 @@ style-loader@^1.0.0:
     loader-utils "^1.2.3"
     schema-utils "^2.6.4"
 
-styled-components@^3.4.9:
-  version "3.4.10"
-  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-3.4.10.tgz#9a654c50ea2b516c36ade57ddcfa296bf85c96e1"
-  integrity sha512-TA8ip8LoILgmSAFd3r326pKtXytUUGu5YWuqZcOQVwVVwB6XqUMn4MHW2IuYJ/HAD81jLrdQed8YWfLSG1LX4Q==
+styled-components@^5.0.1:
+  version "5.0.1"
+  resolved "https://registry.yarnpkg.com/styled-components/-/styled-components-5.0.1.tgz#57782a6471031abefb2db5820a1876ae853bc619"
+  integrity sha512-E0xKTRIjTs4DyvC1MHu/EcCXIj6+ENCP8hP01koyoADF++WdBUOrSGwU1scJRw7/YaYOhDvvoad6VlMG+0j53A==
   dependencies:
-    buffer "^5.0.3"
-    css-to-react-native "^2.0.3"
-    fbjs "^0.8.16"
-    hoist-non-react-statics "^2.5.0"
-    prop-types "^15.5.4"
-    react-is "^16.3.1"
-    stylis "^3.5.0"
-    stylis-rule-sheet "^0.0.10"
-    supports-color "^3.2.3"
+    "@babel/helper-module-imports" "^7.0.0"
+    "@babel/traverse" "^7.4.5"
+    "@emotion/is-prop-valid" "^0.8.3"
+    "@emotion/stylis" "^0.8.4"
+    "@emotion/unitless" "^0.7.4"
+    babel-plugin-styled-components ">= 1"
+    css-to-react-native "^3.0.0"
+    hoist-non-react-statics "^3.0.0"
+    shallowequal "^1.1.0"
+    supports-color "^5.5.0"
 
 stylehacks@^4.0.0:
   version "4.0.3"
@@ -9113,16 +9092,6 @@ stylehacks@^4.0.0:
     browserslist "^4.0.0"
     postcss "^7.0.0"
     postcss-selector-parser "^3.0.0"
-
-stylis-rule-sheet@^0.0.10:
-  version "0.0.10"
-  resolved "https://registry.yarnpkg.com/stylis-rule-sheet/-/stylis-rule-sheet-0.0.10.tgz#44e64a2b076643f4b52e5ff71efc04d8c3c4a430"
-  integrity sha512-nTbZoaqoBnmK+ptANthb10ZRZOGC+EmTLLUxeYIuHNkEKcmKgXX1XWKkUBT2Ac4es3NybooPe0SmvKdhKJZAuw==
-
-stylis@^3.5.0:
-  version "3.5.4"
-  resolved "https://registry.yarnpkg.com/stylis/-/stylis-3.5.4.tgz#f665f25f5e299cf3d64654ab949a57c768b73fbe"
-  integrity sha512-8/3pSmthWM7lsPBKv7NXkzn2Uc9W7NotcwGNpJaa3k7WMM1XDCA4MgT5k/8BIexd5ydZdboXtU90XH9Ec4Bv/Q==
 
 supports-color@6.1.0, supports-color@^6.1.0:
   version "6.1.0"
@@ -9136,14 +9105,7 @@ supports-color@^2.0.0:
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-2.0.0.tgz#535d045ce6b6363fa40117084629995e9df324c7"
   integrity sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=
 
-supports-color@^3.2.3:
-  version "3.2.3"
-  resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-3.2.3.tgz#65ac0504b3954171d8a64946b2ae3cbb8a5f54f6"
-  integrity sha1-ZawFBLOVQXHYpklGsq48u4pfVPY=
-  dependencies:
-    has-flag "^1.0.0"
-
-supports-color@^5.3.0:
+supports-color@^5.3.0, supports-color@^5.5.0:
   version "5.5.0"
   resolved "https://registry.yarnpkg.com/supports-color/-/supports-color-5.5.0.tgz#e2e69a44ac8772f78a1ec0b35b689df6530efc8f"
   integrity sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==
@@ -9498,11 +9460,6 @@ typescript@^3.7.5:
   version "3.7.5"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.7.5.tgz#0692e21f65fd4108b9330238aac11dd2e177a1ae"
   integrity sha512-/P5lkRXkWHNAbcJIiHPfRoKqyd7bsyCma1hZNUGfn20qm64T6ZBlrzprymeu918H+mB/0rIg2gGK/BXkhhYgBw==
-
-ua-parser-js@^0.7.18:
-  version "0.7.21"
-  resolved "https://registry.yarnpkg.com/ua-parser-js/-/ua-parser-js-0.7.21.tgz#853cf9ce93f642f67174273cc34565ae6f308777"
-  integrity sha512-+O8/qh/Qj8CgC6eYBVBykMrNtp5Gebn4dlGD/kKXVkJNDwyrAwSIqwz8CDf+tsAIWVycKcku6gIXJ0qwx/ZXaQ==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"
@@ -9896,11 +9853,6 @@ whatwg-encoding@^1.0.1, whatwg-encoding@^1.0.5:
   integrity sha512-b5lim54JOPN9HtzvK9HFXvBma/rnfFeqsic0hSpjtDbVxR3dJKLc+KB4V6GgiGOvl7CY/KNh8rxSo9DKQrnUEw==
   dependencies:
     iconv-lite "0.4.24"
-
-whatwg-fetch@>=0.10.0:
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/whatwg-fetch/-/whatwg-fetch-3.0.0.tgz#fc804e458cc460009b1a2b966bc8817d2578aefb"
-  integrity sha512-9GSJUgz1D4MfyKU7KRqwOjXCXTqWdFNvEr7eUBYchQiVc744mqK/MzXPNR2WsPkmkOa4ywfg8C2n8h+13Bey1Q==
 
 whatwg-mimetype@^2.2.0, whatwg-mimetype@^2.3.0:
   version "2.3.0"


### PR DESCRIPTION
I wanted to convert the Artsy PR list code over to hooks because hooks are cooler so I went through the conversion and found a few interesting things.

## event handling

The way Rails and React communicate about new Artsy PR events is over a websocket. The websocket code in the `app/views/artsy_pull_requests/index.html.haml` file reads in the new data, creates a custom JS event and dispatches that event to a DOM element. Then React needs to listen to that DOM element for this custom event and update its state to cause a render cycle.

In summary:

* hook comes in from GitHub to the HooksController#create action
  * persist the hook to the database
  * enqueue a job to parse that hook
* hook job executes and verifies the hook is a new artsy pull request
  * fire off a websocket broadcast
* client reads the broadcast in the HAML view and that triggers an event dispatch to the DOM
* the React app listens to those events and a handler is called to update state and cause a render cycle

## writing jest specs

I was happy with this approach in theory but then when I started thinking about converting the React app to hooks and how I would add tests, I found that I didn't like how the React code was coupled to the DOM. The `ArtsyPullRequests` app had a `componentDidMount` function that found the DOM element and used `addEventListener` to be notified about new pull requests. This was fine and I could have converted that to a `useEffect` hook, but then how would I test it?

I mean I could have simulated this by mocking how the DOM element triggered the event, but what I really wanted to be able to do was inject something that would allow me to trigger the handler myself.

## wrapping the DOM events

So what I did was go to the pack file and encapsulate the DOM event management there. I created two functions to start/stop listening to the `NewPullRequest` event and then passed those into the React code as props. That meant that in the body of the new `ArtsyPullRequests` function I would have access to those functions and could provide a handler to be called.

That providing of the handler to be called is the key to how I test this then: I can inject a function that smuggles that handler out into the scope of the jest test where I can call it with a mock event and assert about how that affects rendering.

## other rearranging

I did some other rearranging in this PR to help me stay organized. This is a pretty small React app, but I felt like the responsibilities were a little off. What I ended up with is that the top of the stack, the `ArtsyPullRequests` component, is only responsible for state and wiring up the event listening. It then passes the array of pull requests down to the list which then passes an individual pull request down to the item. Nice and neat.