### PR TITLE
Switch to using lineups

### DIFF
--- a/app/assets/stylesheets/artsy_viewer.sass
+++ b/app/assets/stylesheets/artsy_viewer.sass
@@ -1,47 +1,42 @@
 body
-  background-color: gray
+  background-color: white
   margin: 0
+  margin-left: 10px
   padding: 0
 
   main
+    display: flex
+    gap: 10px
     height: 100vh
+    justify-content: space-between
+    align-items: flex-end
 
     section
-      height: 100vh
-      margin: 0 auto
-      opacity: 1
-      transition: opacity 250ms linear
-
-      &.back
-        opacity: 0
+      display: flex
+      flex-direction: column
 
       img
-        bottom: 0
-        height: 100vh
-        left: 50%
-        position: fixed
-        transform: translate(-50%, 0%)
+        transition: width 300ms ease-in-out, opacity 200ms ease-in-out
 
-
-      footer
-        background-color: black
-        bottom: 0
-        left: 50%
-        margin: 0
-        opacity: 1
-        padding: 0
-        position: fixed
-        transform: translate(-50%, 0%)
-        transition: opacity 250ms linear
-
-        &.hide
+        &.hidden
           opacity: 0
 
+        &.collapsed
+          width: 0 !important
+
+      footer
+        background-color: white
+        margin: 0
+        padding: 0
+
         p
-          background-color: black
-          color: white
+          -webkit-box-orient: vertical
+          -webkit-line-clamp: 1
+          color: black
+          display: -webkit-box
           font-family: verdana
           font-size: 20px
           line-height: 1.8em
-          margin: 0
-          padding: 20px
+          margin: 10px 0 20px
+          overflow: hidden
+          padding: 0

--- a/app/channels/artsy_viewer_channel.rb
+++ b/app/channels/artsy_viewer_channel.rb
@@ -8,6 +8,6 @@ class ArtsyViewerChannel < ApplicationCable::Channel
   private
 
   def initial_payload
-    Artwork.all.sample(10)
+    Lineup.current.artworks
   end
 end

--- a/app/channels/artsy_viewer_channel.rb
+++ b/app/channels/artsy_viewer_channel.rb
@@ -1,13 +1,21 @@
 class ArtsyViewerChannel < ApplicationCable::Channel
   CHANNEL_ID = 'artsy_viewer'.freeze
 
+  def self.broadcast(payload)
+    ActionCable.server.broadcast(
+      CHANNEL_ID,
+      payload
+    )
+  end
+
   def subscribed
     transmit initial_payload
+    stream_from CHANNEL_ID
   end
 
   private
 
   def initial_payload
-    Lineup.current.artworks
+    Lineup.current.as_of(Time.zone.now)
   end
 end

--- a/app/jobs/create_lineup_job.rb
+++ b/app/jobs/create_lineup_job.rb
@@ -1,0 +1,5 @@
+class CreateLineupJob < ApplicationJob
+  def perform
+    Lineup.create_next
+  end
+end

--- a/app/jobs/push_current_lineup_job.rb
+++ b/app/jobs/push_current_lineup_job.rb
@@ -1,0 +1,6 @@
+class PushCurrentLineupJob < ApplicationJob
+  def perform
+    artworks = Lineup.current.as_of(Time.zone.now)
+    ArtsyViewerChannel.broadcast(artworks)
+  end
+end

--- a/app/models/lineup.rb
+++ b/app/models/lineup.rb
@@ -12,6 +12,13 @@ class Lineup < ApplicationRecord
     find_by(current_on: Time.zone.today)
   end
 
+  def as_of(time)
+    lineup_artworks
+      .where('position <= ?', time.hour)
+      .order(position: :asc)
+      .map(&:artwork)
+  end
+
   private
 
   def choose_artworks

--- a/app/models/lineup.rb
+++ b/app/models/lineup.rb
@@ -1,3 +1,8 @@
 class Lineup < ApplicationRecord
   has_many :lineup_artworks, dependent: :destroy
+  has_many :artworks, through: :lineup_artworks
+
+  def self.current
+    find_by(current_on: Time.zone.today)
+  end
 end

--- a/app/models/lineup.rb
+++ b/app/models/lineup.rb
@@ -1,3 +1,3 @@
-class Artwork < ApplicationRecord
+class Lineup < ApplicationRecord
   has_many :lineup_artworks, dependent: :destroy
 end

--- a/app/models/lineup.rb
+++ b/app/models/lineup.rb
@@ -2,7 +2,22 @@ class Lineup < ApplicationRecord
   has_many :lineup_artworks, dependent: :destroy
   has_many :artworks, through: :lineup_artworks
 
+  after_create :choose_artworks
+
+  def self.create_next
+    create(current_on: current.current_on + 1.day)
+  end
+
   def self.current
     find_by(current_on: Time.zone.today)
+  end
+
+  private
+
+  def choose_artworks
+    artwork_ids = Artwork.pluck(:id).sample(24)
+    artwork_ids.each_with_index do |artwork_id, index|
+      lineup_artworks.create(artwork_id: artwork_id, position: index + 1)
+    end
   end
 end

--- a/app/models/lineup_artwork.rb
+++ b/app/models/lineup_artwork.rb
@@ -1,0 +1,4 @@
+class LineupArtwork < ApplicationRecord
+  belongs_to :artwork
+  belongs_to :lineup
+end

--- a/app/views/artsy_viewer/show.html.haml
+++ b/app/views/artsy_viewer/show.html.haml
@@ -3,11 +3,3 @@
   = javascript_include_tag 'application'
 
 %main
-  %section
-    %img
-    %footer
-      %p
-  %section
-    %img
-    %footer
-      %p

--- a/db/migrate/20221108215500_create_lineups.rb
+++ b/db/migrate/20221108215500_create_lineups.rb
@@ -1,0 +1,11 @@
+class CreateLineups < ActiveRecord::Migration[6.1]
+  def change
+    create_table :lineups do |t|
+      t.date :current_on, null: false
+
+      t.timestamps
+    end
+
+    add_index :lineups, :current_on, unique: true
+  end
+end

--- a/db/migrate/20221108221423_create_lineup_artworks.rb
+++ b/db/migrate/20221108221423_create_lineup_artworks.rb
@@ -1,0 +1,11 @@
+class CreateLineupArtworks < ActiveRecord::Migration[6.1]
+  def change
+    create_table :lineup_artworks do |t|
+      t.belongs_to :artwork
+      t.belongs_to :lineup
+      t.integer :position
+
+      t.timestamps
+    end
+  end
+end

--- a/lib/tasks/every.rake
+++ b/lib/tasks/every.rake
@@ -11,7 +11,12 @@ namespace :every do
 
   desc 'Task to run every one day.'
   task one_day: :environment do
-    OneDayJob.perform_later
-    LoadArtworksJob.perform_later
+    job_klasses = [
+      OneDayJob,
+      LoadArtworksJob,
+      CreateLineupJob
+    ]
+
+    job_klasses.each(&:perform_later)
   end
 end

--- a/lib/tasks/every.rake
+++ b/lib/tasks/every.rake
@@ -6,7 +6,12 @@ namespace :every do
 
   desc 'Task to run every one hour.'
   task one_hour: :environment do
-    OneHourJob.perform_later
+    job_klasses = [
+      OneHourJob,
+      PushCurrentLineupJob
+    ]
+
+    job_klasses.each(&:perform_later)
   end
 
   desc 'Task to run every one day.'


### PR DESCRIPTION
This PR changes the Artsy Viewer a lot:

* use webhooks to send updates rather than use a client-side timer
* generate a daily lineup of artworks
* only show the artworks that have been revealed up to now
* animate the newest artwork in
* clean up some visual styling to make the works bigger