### PR TITLE
Make iPad full screen

### DIFF
--- a/app/views/artsy_viewer/show.html.haml
+++ b/app/views/artsy_viewer/show.html.haml
@@ -1,4 +1,5 @@
 - content_for :head do
+  %meta(name="apple-mobile-web-app-capable" content="yes")
   = stylesheet_link_tag 'artsy_viewer', media: 'all'
   = javascript_include_tag 'application'
 


### PR DESCRIPTION
Turns out you have to add this meta tag in order to have it go full screen.