### PR TITLE
Detect notification support

### DIFF
--- a/app/assets/javascripts/artsy_viewer.js
+++ b/app/assets/javascripts/artsy_viewer.js
@@ -1,4 +1,5 @@
 window.onload = () => {
+  const Notification = window.Notification || {}
   const mainElement = document.querySelector('main')
   const mainStyles = window.getComputedStyle(mainElement)
   const heightProperty = mainStyles.getPropertyValue('height')
@@ -85,7 +86,7 @@ window.onload = () => {
     const asideElement = document.createElement("aside")
     asideElement.appendChild(parElement)
 
-    if (!isGranted) {
+    if (Notification.requestPermission && !isGranted) {
       const linkParElement = createLink()
       asideElement.appendChild(linkParElement)
     }


### PR DESCRIPTION
Turns out this is completely unsupported in Safari on iOS. I guess I just didn't think about that hard enough. This PR ensures that if the Notification API is not present, then nothing blows up.