### PR TITLE
Disable some protection

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -17,5 +17,7 @@ module Monolithium
     config.active_record.schema_format = :sql
     config.generators.system_tests = nil
     config.load_defaults 5.1
+
+    config.action_cable.disable_request_forgery_protection = true
   end
 end


### PR DESCRIPTION
This config turns off the protection that only same origin requests would work with the websocket. I think this is fine???