### PR TITLE
Move webdriver group

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -16,6 +16,7 @@ gem 'jbuilder'
 gem 'redcarpet'
 gem 'sass-rails'
 gem 'sidekiq'
+gem 'webdrivers'
 gem 'webpacker'
 
 group :development do
@@ -27,7 +28,6 @@ group :development, :test do
   gem 'pry-rails'
   gem 'rspec-rails'
   gem 'rubocop-rails'
-  gem 'webdrivers'
 end
 
 group :test do


### PR DESCRIPTION
This is an attempt to get Heroku deploying again - not sure why it might be required but we'll see!