### PR TITLE
Add the Word Rot killswitch endpoint

### DIFF
--- a/app/controllers/api/v1/word_rot/killswitch_controller.rb
+++ b/app/controllers/api/v1/word_rot/killswitch_controller.rb
@@ -1,0 +1,14 @@
+module Api
+  module V1
+    module WordRot
+      class KillswitchController < Api::V1Controller
+        skip_before_action :validate_client_token
+
+        def show
+          killswitch = Killswitch.instance
+          render json: killswitch.as_json(only: %i[bad_builds minimum_build])
+        end
+      end
+    end
+  end
+end

--- a/app/models/killswitch.rb
+++ b/app/models/killswitch.rb
@@ -1,0 +1,13 @@
+class Killswitch < ApplicationRecord
+  def self.instance
+    @instance ||= load_instance
+  end
+
+  def self.load_instance
+    killswitch = first || create
+    path = Rails.root.join('config/initializers/killswitch.yml')
+    attrs = YAML.safe_load(File.read(path))
+    killswitch.update(attrs)
+    killswitch
+  end
+end

--- a/config/initializers/killswitch.yml
+++ b/config/initializers/killswitch.yml
@@ -1,0 +1,2 @@
+bad_builds: []
+minimum_build: 3

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -17,7 +17,19 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get :ping, to: 'ping#show'
+
+      namespace :word_rot do
+        get :killswitch, to: 'killswitch#show'
+      end
     end
+  end
+
+  scope :style do
+    get :article, to: 'static#article', as: 'article_styles'
+    get :color, to: 'static#color', as: 'color_styles'
+    get :flashes, to: 'static#flashes', as: 'flashes_styles'
+    get :form, to: 'static#form', as: 'form_styles'
+    get :table, to: 'static#table', as: 'table_styles'
   end
 
   root to: 'static#root'

--- a/db/migrate/20230218205205_create_killswitches.rb
+++ b/db/migrate/20230218205205_create_killswitches.rb
@@ -1,0 +1,9 @@
+class CreateKillswitches < ActiveRecord::Migration[6.1]
+  def change
+    create_table :killswitches do |t|
+      t.integer :bad_builds, array: true, default: []
+      t.integer :minimum_build
+      t.timestamps
+    end
+  end
+end

--- a/spec/requests/api/v1/word_rot/killswitch_spec.rb
+++ b/spec/requests/api/v1/word_rot/killswitch_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+describe 'GET /api/v1/word_rot/killswitch' do
+  it 'returns the instance info' do
+    get '/api/v1/word_rot/killswitch'
+
+    expect(response.status).to eq 200
+    expect(response.parsed_body).to eq(
+      {
+        'bad_builds' => [],
+        'minimum_build' => 3
+      }
+    )
+  end
+end


### PR DESCRIPTION
I took down the little Rails app I was building for Word Rot so the app is trying to phone home for this info and getting a 500. This starts getting Monolithium in a position to do this work instead.