### PR TITLE
Add dashboard page

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -1,0 +1,2 @@
+class DashboardController < ApplicationController
+end

--- a/app/controllers/password_controller.rb
+++ b/app/controllers/password_controller.rb
@@ -3,7 +3,7 @@ class PasswordController < ApplicationController
   before_action :verify_password, only: :create
 
   def create
-    path = session.fetch(:redirect_to, root_path)
+    path = session.fetch(:redirect_to, dashboard_path)
     session.clear
     session[:admin_password] = params[:admin_password]
     flash[:notice] = t("password.saved")

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -1,0 +1,3 @@
+%h1 Dashboard
+%p= link_to "Artsy Viewer", artsy_viewer_path
+%p= link_to "Style Pages", article_styles_path

--- a/app/views/layouts/root.html.haml
+++ b/app/views/layouts/root.html.haml
@@ -4,3 +4,9 @@
     %title Monolithium
     = stylesheet_link_tag 'tailwind'
   %body.bg-monolith.bg-cover.bg-no-repeat.bg-fixed.bg-center
+    - unless flash[:alert].nil?
+      .border.px-6.mb-8.text-sm.bg-purple.text-off-white.border-pink
+        %p= flash[:alert]
+    - unless flash[:notice].nil?
+      .border.px-6.mb-8.text-sm.bg-dark-gray.text-off-white.border-purple
+        %p= flash[:notice]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -3,6 +3,7 @@ Rails.application.routes.draw do
   resources :books, only: %i[create edit new update]
 
   get "artsy-viewer", to: "artsy_viewer#show"
+  get "dashboard", to: "dashboard#show"
   get "faring_direball", to: "faring_direball#index"
 
   get :hooks, to: "hooks#index"

--- a/spec/system/admin_password_spec.rb
+++ b/spec/system/admin_password_spec.rb
@@ -1,12 +1,12 @@
 require "rails_helper"
 
 describe "Admin Password" do
-  xscenario "signing in without redirect_to lands on home page" do
+  scenario "signing in without redirect_to lands on dashboard" do
     visit "/sign_in"
     fill_in "admin_password", with: "shhh"
     click_on "sign in"
     expect(page).to have_content "Password saved to session"
-    expect(current_path).to eq root_path
+    expect(current_path).to eq dashboard_path
   end
 
   scenario "signing in with redirect_to works" do
@@ -17,15 +17,14 @@ describe "Admin Password" do
     expect(current_path).to eq "/projects"
   end
 
-  xscenario "signing out clears session" do
+  scenario "signing out clears session" do
     visit "/sign_in"
     fill_in "admin_password", with: "shhh"
     click_on "sign in"
-    visit "/projects"
-    expect(current_path).to eq "/projects"
-    visit "sign_out"
+    expect(page).to have_content "Password saved to session"
+    visit "/sign_out"
     expect(page).to have_content "Password removed from session"
-    visit "/projects"
+    visit "/dashboard"
     expect(current_path).to eq sign_in_path
   end
 end


### PR DESCRIPTION
This PR adds a new dashboard page where I can list the various things that Monolithium does for quick access. To start I'm only linking the Artsy Viewer and style pages but then as I go adding/fixing things I can add them to this list.