### PR TITLE
Fix pace calculation

### DIFF
--- a/app/controllers/reading_list_controller.rb
+++ b/app/controllers/reading_list_controller.rb
@@ -1,20 +1,3 @@
 class ReadingListController < ApplicationController
-  expose(:year) { params[:year] }
-
-  expose(:books) do
-    start_finished = DateTime.parse("#{year}-01-01")
-    stop_finished = start_finished.end_of_year
-
-    Book
-      .where(finished_on: start_finished..stop_finished)
-      .order(finished_on: :asc, pages: :desc)
-  end
-
-  expose(:total_pages) { books.pluck(:pages).compact.sum }
-
-  expose(:pace) do
-    days_so_far = Time.zone.today.mjd - Time.zone.today.beginning_of_year.mjd
-    exact_pace = (total_pages * 1.0) / days_so_far
-    exact_pace.round(2)
-  end
+  expose(:reading_list) { ReadingList.new(params[:year].to_i) }
 end

--- a/app/models/reading_list.rb
+++ b/app/models/reading_list.rb
@@ -1,0 +1,37 @@
+class ReadingList
+  def initialize(year = Time.now.year)
+    @year = year
+  end
+
+  def books
+    @books ||= select_books
+  end
+
+  def total_pages
+    books.pluck(:pages).compact.sum
+  end
+
+  def pace
+    return if Time.now.year < @year
+
+    exact_pace = (total_pages * 1.0) / days_so_far
+    exact_pace.round(2)
+  end
+
+  private
+
+  def select_books
+    start_finished = DateTime.parse("#{@year}-01-01")
+    stop_finished = start_finished.end_of_year
+
+    Book
+      .where(finished_on: start_finished..stop_finished)
+      .order(finished_on: :asc, pages: :desc)
+  end
+
+  def days_so_far
+    return 365 if Time.now.year > @year
+
+    Time.zone.today.mjd - Time.zone.today.beginning_of_year.mjd
+  end
+end

--- a/app/models/reading_list.rb
+++ b/app/models/reading_list.rb
@@ -1,4 +1,6 @@
 class ReadingList
+  attr_reader :year
+
   def initialize(year = Time.now.year)
     @year = year
   end

--- a/app/views/reading_list/index.html.haml
+++ b/app/views/reading_list/index.html.haml
@@ -1,6 +1,6 @@
-%h1= year
+%h1= reading_list.year
 
-%p #{books.count} books for #{number_with_delimiter total_pages} pages at a pace of #{pace} pages/day.
+%p #{reading_list.books.count} books for #{number_with_delimiter reading_list.total_pages} pages at a pace of #{reading_list.pace} pages/day.
 
 %table.w-full
   %thead
@@ -9,7 +9,7 @@
       %th.text-right Finished
       %th.text-right Pages
   %tbody
-    - books.each do |book|
+    - reading_list.books.each do |book|
       %tr
         %td= link_to book.title, edit_book_path(book)
         %td.text-right= book.finished_on&.strftime("%m/%d")

--- a/spec/models/reading_list_spec.rb
+++ b/spec/models/reading_list_spec.rb
@@ -1,0 +1,135 @@
+require "rails_helper"
+
+describe ReadingList do
+  before do
+    allow(OpenLibrary).to receive(:get_book).and_return(nil)
+  end
+
+  describe "#books" do
+    context "with no books" do
+      it "returns an empty array" do
+        reading_list = ReadingList.new
+        expect(reading_list.books).to eq []
+      end
+    end
+
+    context "with a few books" do
+      it "returns those books" do
+        books = FactoryBot.create_list :book, 3
+        reading_list = ReadingList.new
+        expect(reading_list.books).to eq books
+      end
+    end
+
+    context "with books in other years" do
+      it "does not include those books" do
+        books = FactoryBot.create_list :book, 3
+        FactoryBot.create :book, finished_on: Time.now - 1.year
+        FactoryBot.create :book, finished_on: Time.now + 1.year
+        reading_list = ReadingList.new
+        expect(reading_list.books).to eq books
+      end
+    end
+
+    context "ordering" do
+      def make_book(attrs)
+        date, pages = attrs
+
+        FactoryBot.create(
+          :book,
+          finished_on: DateTime.parse(date),
+          pages: pages
+        )
+      end
+
+      def table_of_books(year)
+        reading_list = ReadingList.new(year)
+
+        reading_list.books.map do |book|
+          [
+            book.finished_on.to_s,
+            book.pages
+          ]
+        end
+      end
+
+      it "orders books by finished date and then pages" do
+        [
+          ["2000-01-01", 100],
+          ["2000-01-02", 100],
+          ["2000-01-01", 200],
+          ["2000-01-02", 300]
+        ].each(&method(:make_book))
+
+        actual = table_of_books("2000")
+
+        expect(actual).to eq(
+          [
+            ["2000-01-01", 200],
+            ["2000-01-01", 100],
+            ["2000-01-02", 300],
+            ["2000-01-02", 100]
+          ]
+        )
+      end
+    end
+  end
+
+  describe "#total_pages" do
+    context "with no books" do
+      it "returns zero" do
+        reading_list = ReadingList.new
+        expect(reading_list.total_pages).to eq 0
+      end
+    end
+
+    context "with a few books" do
+      it "returns the sum of those pages" do
+        FactoryBot.create_list :book, 3, pages: 10
+        reading_list = ReadingList.new
+        expect(reading_list.total_pages).to eq 30
+      end
+    end
+
+    context "with a book that has no pages" do
+      it "skips that book" do
+        FactoryBot.create_list :book, 3, pages: 10
+        FactoryBot.create :book, pages: nil
+        reading_list = ReadingList.new
+        expect(reading_list.total_pages).to eq 30
+      end
+    end
+  end
+
+  describe "#pace" do
+    context "with a year in the past" do
+      it "calculates a pace as of the end of that year" do
+        last_year = Time.now - 1.year
+        FactoryBot.create_list :book, 10, finished_on: last_year, pages: 365
+        reading_list = ReadingList.new(last_year.year)
+        expect(reading_list.pace).to eq 10
+      end
+    end
+
+    context "with a year in the present" do
+      it "calculates a pace as of today" do
+        ides_of_march = DateTime.parse("2000-03-15")
+
+        travel_to ides_of_march do
+          FactoryBot.create_list :book, 2, pages: 100
+          reading_list = ReadingList.new
+          expect(reading_list.pace).to eq 2.7
+        end
+      end
+    end
+
+    context "with a year in the future" do
+      it "returns nil" do
+        next_year = Time.now + 1.year
+        FactoryBot.create_list :book, 10, finished_on: next_year, pages: 365
+        reading_list = ReadingList.new(next_year.year)
+        expect(reading_list.pace).to be_nil
+      end
+    end
+  end
+end

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   config.filter_rails_from_backtrace!
+  config.include ActiveSupport::Testing::TimeHelpers
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = true
 


### PR DESCRIPTION
When things get complicated you should extract an Object! Here I extracted one for the reading list page. Now it can hold onto all that complexity and I can get unit tests around it rather than having to mess with system tests to cover all the bases. This was nice too because it was much easier to see how to actually compute the pace correctly rather than the very naive way I was doing it to start.

Plus I got to use my favorite testing technique: [I/O Tables](https://thoughtbot.com/blog/testing-techniques-the-i-o-table)!!

One more thing: it was really nice to be able to do time travel in my tests without having to install a gem - good job ActiveSupport team!!