### PR TITLE
Add support for raw webhook requests

### DIFF
--- a/app/controllers/api/v1/raw_hooks_controller.rb
+++ b/app/controllers/api/v1/raw_hooks_controller.rb
@@ -1,0 +1,20 @@
+module Api
+  module V1
+    class RawHooksController < Api::V1Controller
+      skip_before_action :validate_client_token
+
+      expose(:raw_hook) do
+        attrs = HookRequest.to_attrs(request, params)
+        RawHook.new(attrs)
+      end
+
+      def create
+        if raw_hook.save
+          head :created
+        else
+          head :unprocessable_entity
+        end
+      end
+    end
+  end
+end

--- a/app/models/hook_request.rb
+++ b/app/models/hook_request.rb
@@ -1,0 +1,42 @@
+class HookRequest
+  def self.to_attrs(request, params)
+    new(request, params).to_attrs
+  end
+
+  attr_reader :request, :params
+
+  def initialize(request, params)
+    @request = request
+    @params = params
+  end
+
+  def to_attrs
+    {
+      body: request_body,
+      headers: loud_headers,
+      params: unsafe_params
+    }
+  end
+
+  private
+
+  def request_body
+    @request_body ||= request.body.read
+  end
+
+  def headers_hash
+    @headers_hash ||= request.headers.to_h
+  end
+
+  def loud_header_keys
+    headers_hash.keys.select { |key| key == key.upcase && !key.starts_with?("ROUTES") }
+  end
+
+  def loud_headers
+    headers_hash.slice(*loud_header_keys)
+  end
+
+  def unsafe_params
+    params.to_unsafe_hash
+  end
+end

--- a/app/models/raw_hook.rb
+++ b/app/models/raw_hook.rb
@@ -1,0 +1,2 @@
+class RawHook < ApplicationRecord
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -16,6 +16,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get :ping, to: "ping#show"
+      post :raw_hooks, to: "raw_hooks#create"
 
       namespace :word_rot do
         get :killswitch, to: "killswitch#show"

--- a/db/migrate/20230305222032_create_raw_hooks.rb
+++ b/db/migrate/20230305222032_create_raw_hooks.rb
@@ -1,0 +1,11 @@
+class CreateRawHooks < ActiveRecord::Migration[7.0]
+  def change
+    create_table :raw_hooks do |t|
+      t.jsonb :headers
+      t.jsonb :params
+      t.text :body
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/requests/api/v1/raw_hooks_spec.rb
+++ b/spec/requests/api/v1/raw_hooks_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+describe "POST /api/v1/raw_hooks" do
+  let(:default_header_keys) do
+    %w[
+      CONTENT_LENGTH
+      CONTENT_TYPE
+      HTTPS
+      HTTP_ACCEPT
+      HTTP_COOKIE
+      HTTP_HOST
+      HTTP_VERSION
+      ORIGINAL_FULLPATH
+      ORIGINAL_SCRIPT_NAME
+      PATH_INFO
+      QUERY_STRING
+      REMOTE_ADDR
+      REQUEST_METHOD
+      REQUEST_URI
+      SCRIPT_NAME
+      SERVER_NAME
+      SERVER_PORT
+      SERVER_PROTOCOL
+    ]
+  end
+
+  let(:default_params) do
+    {
+      "action" => "create",
+      "controller" => "api/v1/raw_hooks"
+    }
+  end
+
+  context "with empty params and headers" do
+    let(:headers) { {} }
+    let(:params) { {} }
+
+    it "stores default params and headers" do
+      post "/api/v1/raw_hooks", params: params, headers: headers
+
+      expect(response.status).to be 201
+      expect(RawHook.count).to eq 1
+
+      raw_hook = RawHook.first
+      expect(default_header_keys).to match_array(raw_hook.headers.keys)
+      expect(raw_hook.params).to eq default_params
+    end
+  end
+
+  context "with extra params and headers" do
+    let(:headers) { {"X-STRING-HEADER" => "token", "X-INTEGER-HEADER" => 7} }
+    let(:params) { {string_param: "password", integer_param: 11} }
+
+    it "stores those too" do
+      post "/api/v1/raw_hooks", params: params, headers: headers
+
+      expect(response.status).to be 201
+      expect(RawHook.count).to eq 1
+
+      raw_hook = RawHook.first
+
+      expect(raw_hook.headers["HTTP_X_STRING_HEADER"]).to eq "token"
+      expect(raw_hook.headers["HTTP_X_INTEGER_HEADER"]).to eq 7
+
+      expect(raw_hook.params["string_param"]).to eq "password"
+      expect(raw_hook.params["integer_param"]).to eq "11"
+    end
+  end
+end


### PR DESCRIPTION
This adds a new POST endpoint to the API so that I can accept raw webhook requests and work on supporting more services. Once this lands then I can point GitHub, CircleCI and Heroku at this endpoint. They should all report that it works fine and then I should also be able to take a look at the payloads/headers to see how they look. At that point I'd want to add a step of verification based on secrets and then a parser to start transforming it into a Hook record.