### PR TITLE
Add Github parser

### DIFF
--- a/app/parsers/github_parser.rb
+++ b/app/parsers/github_parser.rb
@@ -1,0 +1,43 @@
+class GithubParser
+  EVENT_TYPE_KEY = "HTTP_X_GITHUB_EVENT"
+  SIGNATURE_HEADER_KEY = "HTTP_X_HUB_SIGNATURE_256"
+  USER_AGENT_KEY = "HTTP_USER_AGENT"
+
+  KNOWN_EVENT_TYPES = %w[pull_request]
+  KNOWN_USER_AGENT = "GitHub-Hookshot"
+
+  def self.check_and_maybe_parse(raw_hook)
+    parse(raw_hook) if valid_for?(raw_hook) && can_parse?(raw_hook)
+  end
+
+  def self.valid_for?(raw_hook)
+    signature = raw_hook.headers[SIGNATURE_HEADER_KEY] || ""
+    actual_hmac = signature.split("=").last
+    return false unless actual_hmac.present?
+
+    digest = OpenSSL::Digest.new("sha256")
+    secret = Monolithium.config.hub_signature
+    expected_hmac = OpenSSL::HMAC.hexdigest(digest, secret, raw_hook.body)
+
+    Rack::Utils.secure_compare(actual_hmac, expected_hmac)
+  end
+
+  def self.can_parse?(raw_hook)
+    header_keys = raw_hook.headers.keys
+    return false unless header_keys.any?
+
+    header_keys.include?(SIGNATURE_HEADER_KEY) &&
+      raw_hook.headers[USER_AGENT_KEY].include?(KNOWN_USER_AGENT) &&
+      KNOWN_EVENT_TYPES.include?(raw_hook.headers[EVENT_TYPE_KEY])
+  end
+
+  def self.parse(raw_hook)
+    parsed = JSON.parse(raw_hook.body)
+    message = [
+      parsed["repository"]["name"],
+      raw_hook.headers[EVENT_TYPE_KEY],
+      parsed["action"]
+    ].compact.join(" ")
+    raw_hook.create_hook(message: message)
+  end
+end


### PR DESCRIPTION
This is a very naive PR but does establish some parsing of GitHub webhooks. It uses the same patterns as the Heroku and CircleCI ones but only handles PR-related webhooks. Next up would be to improve the support here for all the hooks that won't be valid.