### PR TITLE
Make a post bin

### DIFF
--- a/app/controllers/admin/post_bin_requests_controller.rb
+++ b/app/controllers/admin/post_bin_requests_controller.rb
@@ -1,0 +1,4 @@
+class Admin::PostBinRequestsController < ApplicationController
+  expose(:post_bin_request)
+  expose(:post_bin_requests) { PostBinRequest.all.order(created_at: :desc).limit(10) }
+end

--- a/app/controllers/api/v1/post_bin_controller.rb
+++ b/app/controllers/api/v1/post_bin_controller.rb
@@ -1,0 +1,15 @@
+module Api
+  module V1
+    class PostBinController < Api::V1Controller
+      expose(:post_bin_request) do
+        attrs = HookRequest.to_attrs(request, params)
+        PostBinRequest.new(attrs)
+      end
+
+      def create
+        post_bin_request.save
+        head :created
+      end
+    end
+  end
+end

--- a/app/models/post_bin_request.rb
+++ b/app/models/post_bin_request.rb
@@ -1,0 +1,11 @@
+class PostBinRequest < ApplicationRecord
+  CHANNEL_NAME = "post_bin_requests"
+
+  after_create_commit :created
+
+  private
+
+  def created
+    broadcast_prepend_later_to CHANNEL_NAME
+  end
+end

--- a/app/views/admin/post_bin_requests/index.html.haml
+++ b/app/views/admin/post_bin_requests/index.html.haml
@@ -1,0 +1,4 @@
+%h1 Post Bin Requests
+
+= turbo_stream_from(PostBinRequest::CHANNEL_NAME)
+%ul#post_bin_requests= render partial: "post_bin_requests/post_bin_request", collection: post_bin_requests

--- a/app/views/admin/post_bin_requests/show.html.haml
+++ b/app/views/admin/post_bin_requests/show.html.haml
@@ -1,0 +1,16 @@
+%h1 Post Bin Request #{post_bin_request.id}
+
+%p Headers
+
+%pre.text-off-black
+  %code= JSON.pretty_generate(post_bin_request.headers)
+
+%p Params
+
+%pre.text-off-black
+  %code= JSON.pretty_generate(post_bin_request.params)
+
+%p Body
+
+%pre.text-off-black
+  %code= post_bin_request.body

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -7,6 +7,7 @@
 
 %h2 Admin Pages
 %p= link_to "Books", new_admin_book_path
+%p= link_to "Post Bin", admin_post_bin_requests_path
 %p= link_to "Project List", admin_projects_path
 
 %h2 Api Routes

--- a/app/views/post_bin_requests/_post_bin_request.html.haml
+++ b/app/views/post_bin_requests/_post_bin_request.html.haml
@@ -1,0 +1,1 @@
+%li= link_to post_bin_request.id, admin_post_bin_request_path(post_bin_request)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -12,6 +12,7 @@ Rails.application.routes.draw do
   namespace :api do
     namespace :v1 do
       get :ping, to: "ping#show"
+      post :post_bin, to: "post_bin#create"
       post :raw_hooks, to: "raw_hooks#create"
 
       namespace :word_rot do
@@ -23,8 +24,9 @@ Rails.application.routes.draw do
   namespace :admin do
     resources :books, only: %i[create edit new update]
     resources :hooks, only: %i[create edit index]
-    resources :raw_hooks, only: %i[show]
     resources :projects, only: %i[create index update]
+    resources :post_bin_requests, only: %i[index show]
+    resources :raw_hooks, only: %i[show]
   end
 
   scope :style do

--- a/db/migrate/20230317223542_create_post_bin_requests.rb
+++ b/db/migrate/20230317223542_create_post_bin_requests.rb
@@ -1,0 +1,11 @@
+class CreatePostBinRequests < ActiveRecord::Migration[7.0]
+  def change
+    create_table :post_bin_requests do |t|
+      t.jsonb :headers
+      t.jsonb :params
+      t.text :body
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/requests/api/v1/post_bin_spec.rb
+++ b/spec/requests/api/v1/post_bin_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe "POST /api/v1/post_bin" do
+  context "without a client token" do
+    it "returns an empty 404" do
+      post "/api/v1/post_bin"
+      expect(response.status).to eq 404
+    end
+  end
+
+  context "with an invalid client token" do
+    it "returns an empty 404" do
+      headers = {"X-Client-Token" => "invalid"}
+      post "/api/v1/post_bin", headers: headers
+      expect(response.status).to eq 404
+    end
+  end
+
+  context "with a valid client token" do
+    it "returns an empty 201 and creates a PostBin record" do
+      headers = {"X-Client-Token" => Monolithium.config.client_token}
+      post "/api/v1/post_bin", headers: headers
+      expect(response.status).to eq 201
+      expect(PostBinRequest.count).to eq 1
+    end
+  end
+end


### PR DESCRIPTION
Twice this week I wished I had a post bin endpoint of my own so I could troubleshoot something else I was working on. This PR adds an api endpoint like this:

POST /api/v1/post_bin

And it'll capture the headers, params and body of the request as long as the client token matches. Then I also made an index and show page. I hooked it up to Turbo so the posts will come in over a websocket when I'm looking at the list. Probably overkill but it was too easy NOT to do it. Looks like this:

<img width="1582" alt="Screenshot 2023-03-18 at 6 36 42 PM" src="https://user-images.githubusercontent.com/79799/226145520-589251dd-fac5-4060-ac0e-24c64836f82b.png">


/cc @laurabeth