### PR TITLE
Admin views model counts

### DIFF
--- a/app/controllers/admin/model_counts_controller.rb
+++ b/app/controllers/admin/model_counts_controller.rb
@@ -1,0 +1,3 @@
+class Admin::ModelCountsController < ApplicationController
+  expose(:model_counts) { ModelCounts.calculate }
+end

--- a/app/models/model_counts.rb
+++ b/app/models/model_counts.rb
@@ -1,0 +1,9 @@
+class ModelCounts
+  def self.calculate
+    Rails.application.eager_load!
+    klasses = ApplicationRecord.descendants.map(&:to_s).sort
+    klasses.each_with_object({}) do |klass, memo|
+      memo[klass] = klass.constantize.count
+    end
+  end
+end

--- a/app/views/admin/model_counts/index.html.haml
+++ b/app/views/admin/model_counts/index.html.haml
@@ -1,0 +1,16 @@
+%h1 Model Counts
+
+- if model_counts.nil?
+  %p No models - create one!
+
+- else
+  %table.w-full
+    %thead
+      %tr
+        %th Model
+        %th.text-right Count
+    %tbody
+      - model_counts.each do |(klass, count)|
+        %tr
+          %td= klass
+          %td.text-right= number_with_delimiter count

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -10,6 +10,7 @@
 %h2 Admin Pages
 %p= link_to "Books", new_admin_book_path
 %p= link_to "Gift Ideas", admin_gift_ideas_path
+%p= link_to "Model Counts", admin_model_counts_path
 %p= link_to "Post Bin", admin_post_bin_requests_path
 %p= link_to "Project List", admin_projects_path
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,7 +25,7 @@ Rails.application.routes.draw do
   end
 
   namespace :admin do
-    get "model_counts", to: "model_counts#index"
+    get "model_counts", to: "model_counts#index", as: :model_counts
 
     resources :books, only: %i[create edit new update]
     resources :gift_ideas

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -25,11 +25,13 @@ Rails.application.routes.draw do
   end
 
   namespace :admin do
+    get "model_counts", to: "model_counts#index"
+
     resources :books, only: %i[create edit new update]
     resources :gift_ideas
     resources :hooks, only: %i[create edit index]
-    resources :projects, only: %i[create index update]
     resources :post_bin_requests, only: %i[index show]
+    resources :projects, only: %i[create index update]
     resources :raw_hooks, only: %i[show]
   end
 

--- a/spec/factories/hook.rb
+++ b/spec/factories/hook.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :hook do
+    message { "" }
+    raw_hook
+    webhook_sender
+  end
+end

--- a/spec/factories/killswitch.rb
+++ b/spec/factories/killswitch.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :killswitch do
+    bad_builds { [0] }
+    minimum_build { 1 }
+  end
+end

--- a/spec/factories/lineup_artwork.rb
+++ b/spec/factories/lineup_artwork.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :lineup_artwork do
+    artwork
+    lineup
+    position { 0 }
+  end
+end

--- a/spec/factories/post_bin_request.rb
+++ b/spec/factories/post_bin_request.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :post_bin_request do
+    body { "" }
+    headers { {} }
+    params { {} }
+  end
+end

--- a/spec/factories/webhook_sender.rb
+++ b/spec/factories/webhook_sender.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :webhook_sender do
+    name { "Circle CI" }
+    parser { "CircleciParser" }
+  end
+end

--- a/spec/system/admin/admin_views_model_counts_spec.rb
+++ b/spec/system/admin/admin_views_model_counts_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+
+describe "Admin views model counts" do
+  include_context "admin password matches"
+
+  scenario "with no models" do
+    visit "/admin/model_counts"
+
+    actual_rows = page.all("tbody tr").map(&:text)
+
+    expected_rows = [
+      "Artwork 0",
+      "Book 0",
+      "GiftIdea 0",
+      "Hook 0",
+      "Killswitch 0",
+      "Lineup 0",
+      "LineupArtwork 0",
+      "PostBinRequest 0",
+      "Project 0",
+      "RawHook 0",
+      "WebhookSender 0"
+    ]
+
+    expect(actual_rows).to match_array(expected_rows)
+  end
+
+  scenario "with some models" do
+    FactoryBot.create(:book)
+    FactoryBot.create(:gift_idea)
+    FactoryBot.create(:killswitch)
+    FactoryBot.create(:post_bin_request)
+    FactoryBot.create(:project)
+
+    lineup = FactoryBot.create(:lineup)
+
+    FactoryBot.create(
+      :lineup_artwork,
+      artwork: FactoryBot.create(:artwork),
+      lineup: lineup
+    )
+
+    FactoryBot.create(
+      :hook,
+      raw_hook: FactoryBot.create(:raw_hook),
+      webhook_sender: FactoryBot.create(:webhook_sender)
+    )
+
+    visit "/admin/model_counts"
+
+    actual_rows = page.all("tbody tr").map(&:text)
+
+    expected_rows = [
+      "Artwork 1",
+      "Book 1",
+      "GiftIdea 1",
+      "Hook 1",
+      "Killswitch 1",
+      "Lineup 1",
+      "LineupArtwork 1",
+      "PostBinRequest 1",
+      "Project 1",
+      "RawHook 1",
+      "WebhookSender 1"
+    ]
+
+    expect(actual_rows).to match_array(expected_rows)
+  end
+end


### PR DESCRIPTION
This PR adds an admin screen for checking the counts of the models in the system - looks like this:

<img width="1147" alt="Screenshot 2023-08-01 at 3 01 20 PM" src="https://github.com/jonallured/monolithium/assets/79799/e58ef228-dd08-4751-b314-2a41b723ab11">

I also added it to the Dashboard for easier access.