### PR TITLE
Re-establish some Forty functionality

### DIFF
--- a/app/controllers/today_controller.rb
+++ b/app/controllers/today_controller.rb
@@ -1,0 +1,6 @@
+class TodayController < ApplicationController
+  def show
+    target = TargetSlug.for(Time.zone.today)
+    redirect_to work_week_path(target)
+  end
+end

--- a/app/controllers/work_weeks_controller.rb
+++ b/app/controllers/work_weeks_controller.rb
@@ -1,0 +1,6 @@
+class WorkWeeksController < ApplicationController
+  expose(:work_week) do
+    year, number = params[:target].split("-")
+    WorkWeek.find_or_create(year, number)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,18 @@
 module ApplicationHelper
+  def last_week_path(work_week)
+    target_date = work_week.target_date - 1.week
+    target = TargetSlug.for(target_date)
+    work_week_path(target)
+  end
+
+  def next_week_path(work_week)
+    target_date = work_week.target_date + 1.week
+    target = TargetSlug.for(target_date)
+    work_week_path(target)
+  end
+
+  def this_week_path
+    target = TargetSlug.for(Time.zone.today)
+    work_week_path(target)
+  end
 end

--- a/app/models/target_slug.rb
+++ b/app/models/target_slug.rb
@@ -1,0 +1,7 @@
+class TargetSlug
+  def self.for(date)
+    year = date.cwyear
+    week = date.strftime("%V")
+    [year, week].join("-")
+  end
+end

--- a/app/models/work_day.rb
+++ b/app/models/work_day.rb
@@ -1,0 +1,7 @@
+class WorkDay < ApplicationRecord
+  validates :date, presence: true
+
+  def day_of_week
+    date.strftime("%A")
+  end
+end

--- a/app/models/work_week.rb
+++ b/app/models/work_week.rb
@@ -1,0 +1,54 @@
+class WorkWeek
+  class InvalidDates < StandardError; end
+
+  attr_accessor :work_days
+
+  def self.find_or_create(year, number)
+    work_week = new(year, number)
+    work_week.find_or_create
+    work_week
+  rescue InvalidDates
+    # year and/or number failed to parse as valid date
+  end
+
+  def initialize(year, number)
+    @year = year.to_i
+    @number = number.to_i
+    @work_days = []
+  end
+
+  def find_or_create
+    self.work_days = dates.map do |date|
+      WorkDay.find_or_create_by!(date: date)
+    end
+  end
+
+  def date_span
+    monday = dates.first
+    friday = dates.last
+    (monday..friday).to_formatted_s(:date_span)
+  end
+
+  def target_date
+    dates.first
+  end
+
+  private
+
+  def week_to_date_ids
+    days = work_days.select { |day| day.date <= Time.zone.today }
+    days.map(&:id)
+  end
+
+  def dates
+    @dates ||= compute_dates
+  end
+
+  def compute_dates
+    raise InvalidDates unless @year.positive? && @number.positive?
+
+    (1..5).map { |day| Date.commercial(@year, @number, day) }
+  rescue
+    raise InvalidDates
+  end
+end

--- a/app/views/work_weeks/show.html.haml
+++ b/app/views/work_weeks/show.html.haml
@@ -1,0 +1,15 @@
+%h1 0:00
+%p -24:00
+%p= work_week.date_span
+%p= link_to "<", last_week_path(work_week)
+%p= link_to "this week", this_week_path
+%p= link_to ">", next_week_path(work_week)
+
+- work_week.work_days.each do |work_day|
+  %h2= work_day.day_of_week
+  %p= work_day.id
+  %input{type: "text", placeholder: "in", value: work_day.in_minutes}
+  %input{type: "text", placeholder: "out", value: work_day.out_minutes}
+  %input{type: "text", placeholder: "pto", value: work_day.pto_minutes}
+  %input{type: "text", placeholder: "adjust", value: work_day.adjust_minutes}
+  %p 0:00

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,0 +1,14 @@
+Date::DATE_FORMATS[:standard] = "%m/%d/%Y"
+
+Range::RANGE_FORMATS[:date_span] = proc do |start, stop|
+  same_year = start.year == stop.year
+  same_month = start.month == stop.month
+
+  rhs_format = same_month ? "%d, %Y" : "%b %d, %Y"
+  rhs = stop.strftime(rhs_format)
+
+  lhs_format = same_year ? "%b %d" : "%b %d, %Y"
+  lhs = start.strftime(lhs_format)
+
+  [lhs, rhs].join("-")
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -5,6 +5,8 @@ Rails.application.routes.draw do
   get "faring_direball", to: "faring_direball#index"
   get "reading-list/:year", to: "reading_list#index", as: "reading_list"
   get "wishlist", to: "wishlist#index"
+  get "work_weeks/:target", to: "work_weeks#show", as: :work_week
+  get :today, to: "today#show"
 
   resources :gift_ideas, only: %i[update]
 

--- a/db/migrate/20230906004634_create_work_days_again.rb
+++ b/db/migrate/20230906004634_create_work_days_again.rb
@@ -1,0 +1,14 @@
+class CreateWorkDaysAgain < ActiveRecord::Migration[7.0]
+  def change
+    create_table :work_days do |t|
+      t.date :date, null: false
+
+      t.integer :adjust_minutes
+      t.integer :in_minutes
+      t.integer :out_minutes
+      t.integer :pto_minutes
+
+      t.timestamps
+    end
+  end
+end

--- a/spec/factories/work_day.rb
+++ b/spec/factories/work_day.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :work_day do
+    date { Date.today }
+  end
+end

--- a/spec/models/work_week_spec.rb
+++ b/spec/models/work_week_spec.rb
@@ -1,0 +1,60 @@
+require "rails_helper"
+
+describe WorkWeek do
+  describe ".find_or_create" do
+    context "with an invalid year" do
+      it "returns nil" do
+        work_week = WorkWeek.find_or_create("asdf", "1")
+        expect(work_week).to be_nil
+      end
+    end
+
+    context "with an invalid number" do
+      it "returns nil" do
+        work_week = WorkWeek.find_or_create("2017", "asdf")
+        expect(work_week).to be_nil
+      end
+    end
+
+    context "with an existing year and number" do
+      it "returns a WorkWeek with those existing WorkDay records" do
+        monday = FactoryBot.create :work_day, date: "2017-01-02"
+        tuesday = FactoryBot.create :work_day, date: "2017-01-03"
+        wednesday = FactoryBot.create :work_day, date: "2017-01-04"
+        thursday = FactoryBot.create :work_day, date: "2017-01-05"
+        friday = FactoryBot.create :work_day, date: "2017-01-06"
+
+        work_week = WorkWeek.find_or_create("2017", "1")
+
+        expect(WorkDay.count).to eq 5
+        expect(work_week.work_days).to eq(
+          [
+            monday,
+            tuesday,
+            wednesday,
+            thursday,
+            friday
+          ]
+        )
+      end
+    end
+
+    context "with a new year and number" do
+      it "creates WorkDay records and returns a WorkWeek for them" do
+        expect(WorkDay.count).to eq 0
+        work_week = WorkWeek.find_or_create("2017", "1")
+        expect(WorkDay.count).to eq 5
+        dates = work_week.work_days.map(&:date).map(&:to_s)
+        expect(dates).to eq(
+          %w[
+            2017-01-02
+            2017-01-03
+            2017-01-04
+            2017-01-05
+            2017-01-06
+          ]
+        )
+      end
+    end
+  end
+end

--- a/spec/system/admin/admin_views_model_counts_spec.rb
+++ b/spec/system/admin/admin_views_model_counts_spec.rb
@@ -19,7 +19,8 @@ describe "Admin views model counts" do
       "PostBinRequest 0",
       "Project 0",
       "RawHook 0",
-      "WebhookSender 0"
+      "WebhookSender 0",
+      "WorkDay 0"
     ]
 
     expect(actual_rows).to match_array(expected_rows)
@@ -46,6 +47,8 @@ describe "Admin views model counts" do
       webhook_sender: FactoryBot.create(:webhook_sender)
     )
 
+    FactoryBot.create(:work_day)
+
     visit "/admin/model_counts"
 
     actual_rows = page.all("tbody tr").map(&:text)
@@ -61,11 +64,12 @@ describe "Admin views model counts" do
       "PostBinRequest 1",
       "Project 1",
       "RawHook 1",
-      "WebhookSender 1"
+      "WebhookSender 1",
+      "WorkDay 1"
     ]
 
     expect(actual_rows).to match_array(expected_rows)
 
-    expect(page.find("tfoot tr").text).to eq "Total 11"
+    expect(page.find("tfoot tr").text).to eq "Total 12"
   end
 end


### PR DESCRIPTION
This PR re-establishes some Forty functionality by creating the modeling required to migrate the data and some very basic UI. The actual work day entry screen is far from working but this is enough to get the data back into Monolithium. From there I can continue working on this but not be concerned about the data. I can also fully remove Forty from Heroku.