### PR TITLE
Support client token in params

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,4 +1,6 @@
 class ApiController < ActionController::Base
+  CLIENT_TOKEN_HEADER = "X-MLI-CLIENT-TOKEN"
+
   protect_from_forgery with: :null_session
 
   before_action :validate_client_token
@@ -6,7 +8,7 @@ class ApiController < ActionController::Base
   private
 
   def client_token_valid?
-    client_token = request.headers["X-CLIENT-TOKEN"]
+    client_token = request.headers[CLIENT_TOKEN_HEADER]
     Monolithium.config.client_token == client_token
   end
 

--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,5 +1,6 @@
 class ApiController < ActionController::Base
   CLIENT_TOKEN_HEADER = "X-MLI-CLIENT-TOKEN"
+  CLIENT_TOKEN_PARAM = :mli_client_token
 
   protect_from_forgery with: :null_session
 
@@ -8,7 +9,7 @@ class ApiController < ActionController::Base
   private
 
   def client_token_valid?
-    client_token = request.headers[CLIENT_TOKEN_HEADER]
+    client_token = request.headers[CLIENT_TOKEN_HEADER] || params[CLIENT_TOKEN_PARAM]
     Monolithium.config.client_token == client_token
   end
 

--- a/app/models/hook_request.rb
+++ b/app/models/hook_request.rb
@@ -21,7 +21,7 @@ class HookRequest
   private
 
   def request_body
-    @request_body ||= request.body.read
+    @request_body ||= request.body&.read
   end
 
   def headers_hash

--- a/app/models/hook_request.rb
+++ b/app/models/hook_request.rb
@@ -3,6 +3,10 @@ class HookRequest
     ApiController::CLIENT_TOKEN_HEADER
   ]
 
+  SECRET_HEADER_PARAMS = [
+    ApiController::CLIENT_TOKEN_PARAM
+  ]
+
   def self.to_attrs(request, params)
     new(request, params).to_attrs
   end
@@ -45,6 +49,12 @@ class HookRequest
   end
 
   def computed_params
-    params.to_unsafe_hash
+    unsafe_params = params.to_unsafe_hash
+
+    SECRET_HEADER_PARAMS.each do |secret_param|
+      unsafe_params[secret_param] = "REDACTED" if unsafe_params.key? secret_param
+    end
+
+    unsafe_params
   end
 end

--- a/spec/models/hook_request_spec.rb
+++ b/spec/models/hook_request_spec.rb
@@ -47,6 +47,15 @@ describe HookRequest do
       end
     end
 
+    context "with a client token header" do
+      let(:env) { {ApiController::CLIENT_TOKEN_HEADER => "shhh"} }
+
+      it "redacts that header value" do
+        attrs = HookRequest.to_attrs(request, params)
+        expect(attrs[:headers][ApiController::CLIENT_TOKEN_HEADER]).to eq "REDACTED"
+      end
+    end
+
     context "with a param that has not been permitted" do
       let(:parameters) { {unsafe: "don't ignore me!"} }
 

--- a/spec/models/hook_request_spec.rb
+++ b/spec/models/hook_request_spec.rb
@@ -64,5 +64,14 @@ describe HookRequest do
         expect(attrs[:params][:unsafe]).to eq "don't ignore me!"
       end
     end
+
+    context "with a client token param" do
+      let(:parameters) { {ApiController::CLIENT_TOKEN_PARAM => "shhh"} }
+
+      it "redacts that header value" do
+        attrs = HookRequest.to_attrs(request, params)
+        expect(attrs[:params][ApiController::CLIENT_TOKEN_PARAM]).to eq "REDACTED"
+      end
+    end
   end
 end

--- a/spec/models/hook_request_spec.rb
+++ b/spec/models/hook_request_spec.rb
@@ -1,0 +1,59 @@
+require "rails_helper"
+
+describe HookRequest do
+  describe ".to_attrs" do
+    let(:env) { {} }
+    let(:request) { ActionDispatch::Request.new(env) }
+
+    let(:parameters) { {} }
+    let(:params) { ActionController::Parameters.new(parameters) }
+
+    before do
+      params.permit(:safe)
+    end
+
+    context "with a typical request" do
+      let(:env) do
+        rack_input = StringIO.new("typical request body")
+        {"rack.input" => rack_input, "UPPER" => "typical request header"}
+      end
+
+      let(:parameters) { {safe: "typical request param"} }
+
+      it "returns the body, headers and params from the request" do
+        attrs = HookRequest.to_attrs(request, params)
+
+        expect(attrs[:body]).to eq "typical request body"
+        expect(attrs[:headers]["UPPER"]).to eq "typical request header"
+        expect(attrs[:params][:safe]).to eq "typical request param"
+      end
+    end
+
+    context "with a lowercase header" do
+      let(:env) { {"lower" => "ignore me!"} }
+
+      it "ignores that header" do
+        attrs = HookRequest.to_attrs(request, params)
+        expect(attrs[:headers].keys).to_not include "lower"
+      end
+    end
+
+    context "with a header that starts with 'ROUTES'" do
+      let(:env) { {"ROUTES_KEY" => "ignore me!"} }
+
+      it "ignores that header" do
+        attrs = HookRequest.to_attrs(request, params)
+        expect(attrs[:headers].keys).to_not include "ROUTES_KEY"
+      end
+    end
+
+    context "with a param that has not been permitted" do
+      let(:parameters) { {unsafe: "don't ignore me!"} }
+
+      it "does not igore that param" do
+        attrs = HookRequest.to_attrs(request, params)
+        expect(attrs[:params][:unsafe]).to eq "don't ignore me!"
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/post_bin_spec.rb
+++ b/spec/requests/api/v1/post_bin_spec.rb
@@ -24,4 +24,30 @@ describe "POST /api/v1/post_bin" do
       expect(PostBinRequest.count).to eq 1
     end
   end
+
+  context "with an invalid client token param" do
+    it "returns an empty 404" do
+      params = {ApiController::CLIENT_TOKEN_PARAM => "invalid"}
+      post "/api/v1/post_bin", params: params
+      expect(response.status).to eq 404
+    end
+  end
+
+  context "with a valid client token param" do
+    it "returns an empty 201 and creates a PostBin record" do
+      params = {ApiController::CLIENT_TOKEN_PARAM => Monolithium.config.client_token}
+      post "/api/v1/post_bin", params: params
+      expect(response.status).to eq 201
+      expect(PostBinRequest.count).to eq 1
+    end
+  end
+
+  context "with an invalid client token header and a valid client token param" do
+    it "returns an empty 404" do
+      params = {ApiController::CLIENT_TOKEN_PARAM => Monolithium.config.client_token}
+      headers = {ApiController::CLIENT_TOKEN_HEADER => "invalid"}
+      post "/api/v1/post_bin", params: params, headers: headers
+      expect(response.status).to eq 404
+    end
+  end
 end

--- a/spec/requests/api/v1/post_bin_spec.rb
+++ b/spec/requests/api/v1/post_bin_spec.rb
@@ -8,17 +8,17 @@ describe "POST /api/v1/post_bin" do
     end
   end
 
-  context "with an invalid client token" do
+  context "with an invalid client token header" do
     it "returns an empty 404" do
-      headers = {"X-Client-Token" => "invalid"}
+      headers = {ApiController::CLIENT_TOKEN_HEADER => "invalid"}
       post "/api/v1/post_bin", headers: headers
       expect(response.status).to eq 404
     end
   end
 
-  context "with a valid client token" do
+  context "with a valid client token header" do
     it "returns an empty 201 and creates a PostBin record" do
-      headers = {"X-Client-Token" => Monolithium.config.client_token}
+      headers = {ApiController::CLIENT_TOKEN_HEADER => Monolithium.config.client_token}
       post "/api/v1/post_bin", headers: headers
       expect(response.status).to eq 201
       expect(PostBinRequest.count).to eq 1


### PR DESCRIPTION
This PR adds support for passing the client token as a param - prior to this one the token had to be passed as a header. That worked up until I didn't have control over the request being made only the URL. I'm looking at you Sendgrid!

So now these both work:

```
$ http POST https://app.jonallured.com/api/v1/post_bin X-Mli-Client-Token:$CLIENT_TOKEN
$ http POST https://app.jonallured.com/api/v1/post_bin?mli_client_token=$CLIENT_TOKEN
```

I also introduced an update to the `HookRequest` class so that these two are redacted. There weren't any specs for this class so I started by adding some and then went from there.

Note that at the same time I also renamed these to include "mli" to prevent any accidental redactions.