### PR TITLE
Fix redaction for client token in headers

### DIFF
--- a/app/controllers/api_controller.rb
+++ b/app/controllers/api_controller.rb
@@ -1,5 +1,5 @@
 class ApiController < ActionController::Base
-  CLIENT_TOKEN_HEADER = "X-MLI-CLIENT-TOKEN"
+  CLIENT_TOKEN_HEADER = "HTTP_X_MLI_CLIENT_TOKEN"
   CLIENT_TOKEN_PARAM = :mli_client_token
 
   protect_from_forgery with: :null_session
@@ -9,7 +9,7 @@ class ApiController < ActionController::Base
   private
 
   def client_token_valid?
-    client_token = request.headers[CLIENT_TOKEN_HEADER] || params[CLIENT_TOKEN_PARAM]
+    client_token = request.headers.to_h[CLIENT_TOKEN_HEADER] || params[CLIENT_TOKEN_PARAM]
     Monolithium.config.client_token == client_token
   end
 


### PR DESCRIPTION
Ugh - Rails does weird things with HTTP headers so this PR fixes the last one and properly redacts the client token when passed as a header.