### PR TITLE
Add prev/next links to reading list

### DIFF
--- a/app/models/reading_list.rb
+++ b/app/models/reading_list.rb
@@ -5,6 +5,14 @@ class ReadingList
     @year = year
   end
 
+  def prev_year
+    @year - 1
+  end
+
+  def next_year
+    @year + 1
+  end
+
   def books
     @books ||= select_books
   end

--- a/app/views/reading_list/index.html.haml
+++ b/app/views/reading_list/index.html.haml
@@ -1,4 +1,8 @@
-%h1= reading_list.year
+- content_for :header do
+  %nav.flex.justify-between.items-center.py-6.border-b-8.border-dark-gray
+    %p.m-0= link_to "prev", reading_list_path(reading_list.prev_year)
+    %h1.m-0= reading_list.year
+    %p.m-0= link_to "next", reading_list_path(reading_list.next_year)
 
 %p #{reading_list.books.count} books for #{number_with_delimiter reading_list.total_pages} pages at a pace of #{reading_list.pace} pages/day.
 


### PR DESCRIPTION
I wanted a way to navigate between years in the Reading List page but wasn't sure how I was going to do it. I tinkered with add these links conditionally only if the year actually has books but then I realized: I don't really care and it's added complexity for very little benefit. If there aren't books on that year then the table is just empty - who cares?

So then having established that I was always going to have these links show up then my next thought was about how they'd look on the page. I ended up looking at the nav that connects all the style pages and adapted that to this case.

Looks like this:

![Screenshot 2024-01-20 at 2 58 13 PM](https://github.com/jonallured/monolithium/assets/79799/0fa7fe51-4679-4cba-bb60-0206cbc9abe4)
