### PR TITLE
Admin views csv upload

### DIFF
--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -13,4 +13,13 @@ class Book < ApplicationRecord
     }
     update!(open_attrs)
   end
+
+  def table_attrs
+    [
+      ["ISBN", isbn],
+      ["Finished On", finished_on],
+      ["Title", title],
+      ["Pages", pages]
+    ]
+  end
 end

--- a/app/models/csv_upload.rb
+++ b/app/models/csv_upload.rb
@@ -8,4 +8,13 @@ class CsvUpload < ApplicationRecord
   rescue CSV::MalformedCSVError
     nil
   end
+
+  def table_attrs
+    [
+      ["Parser Class Name", parser_class_name],
+      ["Original Filename", original_filename],
+      ["Created At", created_at.to_formatted_s(:long)],
+      ["Updated At", updated_at.to_formatted_s(:long)]
+    ]
+  end
 end

--- a/app/models/gift_idea.rb
+++ b/app/models/gift_idea.rb
@@ -3,4 +3,12 @@ class GiftIdea < ApplicationRecord
   scope :claimed, -> { where("claimed_at IS NOT NULL AND received_at IS NULL") }
   scope :received, -> { where("received_at IS NOT NULL") }
   scope :not_received, -> { where("received_at IS NULL") }
+
+  def table_attrs
+    [
+      ["Title", title],
+      ["Website URL", website_url],
+      ["Note", note]
+    ]
+  end
 end

--- a/app/views/admin/books/edit.html.haml
+++ b/app/views/admin/books/edit.html.haml
@@ -1,18 +1,5 @@
 %h1 Book #{book.id}
 
-%table.w-full
-  %tbody
-    %tr
-      %td ISBN
-      %td.text-right= book.isbn
-    %tr
-      %td Finished On
-      %td.text-right= book.finished_on
-    %tr
-      %td Title
-      %td.text-right= book.title
-    %tr
-      %td Pages
-      %td.text-right= book.pages
+= render partial: "attrs_table", locals: { attrs: book.table_attrs }
 
 = render "form", book: book, button_label: "update"

--- a/app/views/admin/books/edit.html.haml
+++ b/app/views/admin/books/edit.html.haml
@@ -1,20 +1,18 @@
 %h1 Book #{book.id}
 
-%dl
-  .flex.flex-wrap
-    %dt(class="basis-1/2") ISBN
-    %dd.text-right(class="basis-1/2")= book.isbn
-
-  .flex.flex-wrap
-    %dt(class="basis-1/2") Finished On
-    %dd.text-right(class="basis-1/2")= book.finished_on
-
-  .flex.flex-wrap
-    %dt(class="basis-1/2") Title
-    %dd.text-right(class="basis-1/2")= book.title
-
-  .flex.flex-wrap
-    %dt(class="basis-1/2") Pages
-    %dd.text-right(class="basis-1/2")= book.pages
+%table.w-full
+  %tbody
+    %tr
+      %td ISBN
+      %td.text-right= book.isbn
+    %tr
+      %td Finished On
+      %td.text-right= book.finished_on
+    %tr
+      %td Title
+      %td.text-right= book.title
+    %tr
+      %td Pages
+      %td.text-right= book.pages
 
 = render "form", book: book, button_label: "update"

--- a/app/views/admin/csv_uploads/show.html.haml
+++ b/app/views/admin/csv_uploads/show.html.haml
@@ -1,1 +1,8 @@
 %h1 CSV Upload #{csv_upload.id}
+
+= render partial: "attrs_table", locals: { attrs: csv_upload.table_attrs }
+
+%h2 Data
+
+%pre.text-off-black.h-72
+  %code= csv_upload.data

--- a/app/views/admin/gift_ideas/show.html.haml
+++ b/app/views/admin/gift_ideas/show.html.haml
@@ -4,15 +4,14 @@
 
 %p= link_to "edit", edit_admin_gift_idea_path(gift_idea)
 
-%dl
-  .flex.flex-wrap
-    %dt(class="basis-1/2") Title
-    %dd.text-right(class="basis-1/2")= gift_idea.title
-
-  .flex.flex-wrap
-    %dt(class="basis-1/2") Website URL
-    %dd.text-right(class="basis-1/2")= gift_idea.website_url
-
-  .flex.flex-wrap
-    %dt(class="basis-1/2") Note
-    %dd.text-right(class="basis-1/2")= gift_idea.note
+%table.w-full
+  %tbody
+    %tr
+      %td Title
+      %td.text-right= gift_idea.title
+    %tr
+      %td Website URL
+      %td.text-right= gift_idea.website_url
+    %tr
+      %td Note
+      %td.text-right= gift_idea.note

--- a/app/views/admin/gift_ideas/show.html.haml
+++ b/app/views/admin/gift_ideas/show.html.haml
@@ -4,14 +4,4 @@
 
 %p= link_to "edit", edit_admin_gift_idea_path(gift_idea)
 
-%table.w-full
-  %tbody
-    %tr
-      %td Title
-      %td.text-right= gift_idea.title
-    %tr
-      %td Website URL
-      %td.text-right= gift_idea.website_url
-    %tr
-      %td Note
-      %td.text-right= gift_idea.note
+= render partial: "attrs_table", locals: { attrs: gift_idea.table_attrs }

--- a/app/views/application/_attrs_table.html.haml
+++ b/app/views/application/_attrs_table.html.haml
@@ -1,0 +1,6 @@
+%table.w-full
+  %tbody
+    - attrs.each do |(key, value)|
+      %tr
+        %td= key
+        %td.text-right= value

--- a/spec/system/books/admin_creates_book_spec.rb
+++ b/spec/system/books/admin_creates_book_spec.rb
@@ -9,8 +9,8 @@ describe "Admin creates book" do
     fill_in "book[finished_on]", with: "01/01/2000"
     click_on "create"
 
-    actual_values = page.all("dl div").map do |div|
-      [div.find("dt").text, div.find("dd").text]
+    actual_values = page.all("tr").map do |table_row|
+      table_row.all("td").map(&:text)
     end
 
     expect(actual_values).to eq(

--- a/spec/system/csv_uploads/admin_views_csv_upload_spec.rb
+++ b/spec/system/csv_uploads/admin_views_csv_upload_spec.rb
@@ -1,0 +1,33 @@
+require "rails_helper"
+
+describe "Admin views CsvUpload" do
+  include_context "admin password matches"
+
+  scenario "views CsvUpload" do
+    csv_upload = FactoryBot.create(
+      :csv_upload,
+      data: "foo,bar,baz",
+      original_filename: "dummy-data.csv",
+      parser_class_name: "DummyParser"
+    )
+
+    visit "/admin/csv_uploads/#{csv_upload.id}"
+
+    expect(page).to have_content "CSV Upload #{csv_upload.id}"
+
+    actual_values = page.all("tr").map do |table_row|
+      table_row.all("td").map(&:text)
+    end
+
+    expect(actual_values).to eq(
+      [
+        ["Parser Class Name", "DummyParser"],
+        ["Original Filename", "dummy-data.csv"],
+        ["Created At", csv_upload.created_at.to_formatted_s(:long)],
+        ["Updated At", csv_upload.updated_at.to_formatted_s(:long)]
+      ]
+    )
+
+    expect(page.find("code").text).to eq csv_upload.data
+  end
+end

--- a/spec/system/gift_ideas/admin_creates_gift_idea_spec.rb
+++ b/spec/system/gift_ideas/admin_creates_gift_idea_spec.rb
@@ -10,8 +10,8 @@ describe "Admin creates gift idea" do
     fill_in "note", with: "Please get me the actual physical game, thanks!"
     click_on "create"
 
-    actual_values = page.all("dl div").map do |div|
-      [div.find("dt").text, div.find("dd").text]
+    actual_values = page.all("tr").map do |table_row|
+      table_row.all("td").map(&:text)
     end
 
     expect(actual_values).to eq(

--- a/spec/system/gift_ideas/admin_views_gift_idea_spec.rb
+++ b/spec/system/gift_ideas/admin_views_gift_idea_spec.rb
@@ -13,8 +13,8 @@ describe "Admin views gift idea" do
 
     visit "/admin/gift_ideas/#{gift_idea.id}"
 
-    actual_values = page.all("dl div").map do |div|
-      [div.find("dt").text, div.find("dd").text]
+    actual_values = page.all("tr").map do |table_row|
+      table_row.all("td").map(&:text)
     end
 
     expect(actual_values).to eq(


### PR DESCRIPTION
This PR improves the temporary view for showing a CsvUpload record. I added that view just so I could have somewhere for the create page to redirect to but I wanted to return to it next. Here's how it looks:

![Screenshot 2024-02-18 at 10 48 05 AM](https://github.com/jonallured/monolithium/assets/79799/c353bc6c-387e-423b-81e4-54433baf688a)

I was all set to use the existing pattern of doing a DL for the key/values for the model but then I realized that I'd rather just have a table. So I took a step back and found the places I was using the DL and updated them to use a table. Then I extracted a partial and moved the logic for what's in that table up into the models.

Then I was able to return to the CsvUpload show view and easily implement something that I think looks much better.