### PR TITLE
Fully implement crud pages for csv uploads

### DIFF
--- a/app/controllers/admin/csv_uploads_controller.rb
+++ b/app/controllers/admin/csv_uploads_controller.rb
@@ -15,6 +15,12 @@ class Admin::CsvUploadsController < ApplicationController
     end
   end
 
+  def destroy
+    csv_upload.destroy
+    flash.notice = "CSV Upload deleted"
+    redirect_to admin_csv_uploads_path
+  end
+
   private
 
   def csv_upload_params

--- a/app/controllers/admin/csv_uploads_controller.rb
+++ b/app/controllers/admin/csv_uploads_controller.rb
@@ -1,14 +1,16 @@
 class Admin::CsvUploadsController < ApplicationController
   expose(:csv_upload)
-  expose(:csv_uploads) { CsvUpload.order(created_at: :desc).page params[:page] }
+  expose(:csv_uploads) do
+    CsvUpload.order(created_at: :desc).page(params[:page])
+  end
 
   def create
     if csv_upload.save
       ParseCsvUploadJob.perform_later(csv_upload.id)
-      flash.notice = "CSV Upload successfully created"
+      flash.notice = "CSV Upload created"
       redirect_to admin_csv_upload_path(csv_upload)
     else
-      flash.alert = csv_upload.errors.full_messages.join(",")
+      flash.alert = csv_upload.errors.full_messages.to_sentence
       redirect_to new_admin_csv_upload_path
     end
   end

--- a/app/controllers/admin/csv_uploads_controller.rb
+++ b/app/controllers/admin/csv_uploads_controller.rb
@@ -15,6 +15,16 @@ class Admin::CsvUploadsController < ApplicationController
     end
   end
 
+  def update
+    if csv_upload.update(csv_upload_params)
+      flash.notice = "CSV Upload updated"
+      redirect_to admin_csv_upload_path(csv_upload)
+    else
+      flash.alert = csv_upload.errors.full_messages.to_sentence
+      redirect_to edit_admin_csv_upload_path(csv_upload)
+    end
+  end
+
   def destroy
     csv_upload.destroy
     flash.notice = "CSV Upload deleted"
@@ -24,9 +34,13 @@ class Admin::CsvUploadsController < ApplicationController
   private
 
   def csv_upload_params
-    safe_params = params.require(:csv_upload).permit(:parser_class_name)
-    safe_params[:original_filename] = params[:file].original_filename
-    safe_params[:data] = params[:file].read
+    safe_params = params.require(:csv_upload).permit(:original_filename, :parser_class_name)
+
+    if params[:file]
+      safe_params[:original_filename] = params[:file].original_filename
+      safe_params[:data] = params[:file].read
+    end
+
     safe_params
   end
 end

--- a/app/views/admin/csv_uploads/edit.html.haml
+++ b/app/views/admin/csv_uploads/edit.html.haml
@@ -1,0 +1,7 @@
+%h1 Edit CSV Upload #{csv_upload.id}
+
+%p= link_to "Show CSV Upload", admin_csv_upload_path(csv_upload)
+
+= form_with model: [:admin, csv_upload] do |form|
+  = form.text_field :original_filename, placeholder: "original filename"
+  = form.button "update"

--- a/app/views/admin/csv_uploads/show.html.haml
+++ b/app/views/admin/csv_uploads/show.html.haml
@@ -2,6 +2,8 @@
 
 %p= link_to "CSV Upload List", admin_csv_uploads_path
 
+%p= link_to "Delete CSV Upload", admin_csv_upload_path(csv_upload), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }
+
 = render partial: "attrs_table", locals: { attrs: csv_upload.table_attrs }
 
 %h2 Data

--- a/app/views/admin/csv_uploads/show.html.haml
+++ b/app/views/admin/csv_uploads/show.html.haml
@@ -2,6 +2,8 @@
 
 %p= link_to "CSV Upload List", admin_csv_uploads_path
 
+%p= link_to "Edit CSV Upload", edit_admin_csv_upload_path(csv_upload)
+
 %p= link_to "Delete CSV Upload", admin_csv_upload_path(csv_upload), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }
 
 = render partial: "attrs_table", locals: { attrs: csv_upload.table_attrs }

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :books, only: %i[create edit new update]
-    resources :csv_uploads, only: %i[create destroy index new show]
+    resources :csv_uploads
     resources :financial_accounts
     resources :gift_ideas
     resources :hooks, only: %i[create edit index]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -26,7 +26,7 @@ Rails.application.routes.draw do
 
   namespace :admin do
     resources :books, only: %i[create edit new update]
-    resources :csv_uploads, only: %i[create index new show]
+    resources :csv_uploads, only: %i[create destroy index new show]
     resources :financial_accounts
     resources :gift_ideas
     resources :hooks, only: %i[create edit index]

--- a/spec/system/csv_uploads/admin_deletes_csv_upload_spec.rb
+++ b/spec/system/csv_uploads/admin_deletes_csv_upload_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe "Admin deletes csv upload" do
+  include_context "admin password matches"
+
+  let(:csv_upload) { FactoryBot.create(:csv_upload) }
+
+  scenario "cancels delete" do
+    visit "/admin/csv_uploads/#{csv_upload.id}"
+
+    dismiss_confirm { click_on "Delete CSV Upload" }
+
+    expect(CsvUpload.count).to eq 1
+    expect(current_path).to eq admin_csv_upload_path(csv_upload)
+  end
+
+  scenario "confirms delete" do
+    visit "/admin/csv_uploads/#{csv_upload.id}"
+
+    accept_confirm { click_on "Delete CSV Upload" }
+
+    expect(page).to have_css ".notice", text: "CSV Upload deleted"
+
+    expect(CsvUpload.count).to eq 0
+    expect(current_path).to eq admin_csv_uploads_path
+  end
+end

--- a/spec/system/csv_uploads/admin_edits_financial_account_spec.rb
+++ b/spec/system/csv_uploads/admin_edits_financial_account_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe "Admin edits csv upload" do
+  include_context "admin password matches"
+
+  scenario "from show page" do
+    csv_upload = FactoryBot.create(:csv_upload)
+    visit "/admin/csv_uploads/#{csv_upload.id}"
+    click_on "Edit CSV Upload"
+    expect(page).to have_css "h1", text: "Edit CSV Upload #{csv_upload.id}"
+    expect(page).to have_css "a", text: "Show CSV Upload"
+    expect(current_path).to eq edit_admin_csv_upload_path(csv_upload)
+  end
+
+  scenario "edit with errors" do
+    csv_upload = FactoryBot.create(:csv_upload)
+    visit "/admin/csv_uploads/#{csv_upload.id}/edit"
+    fill_in "original filename", with: ""
+    click_on "update"
+    expect(page).to have_css ".alert", text: "Original filename can't be blank"
+  end
+
+  scenario "edit successfully" do
+    csv_upload = FactoryBot.create(
+      :csv_upload,
+      original_filename: "some-gret-data.csl"
+    )
+    visit "/admin/csv_uploads/#{csv_upload.id}/edit"
+    fill_in "original filename", with: "some-great-data.csv"
+    click_on "update"
+
+    expect(page).to have_css ".notice", text: "CSV Upload updated"
+    expect(current_path).to eq admin_csv_upload_path(csv_upload)
+    expect(page).to have_css "td", text: "some-great-data.csv"
+  end
+end

--- a/spec/system/csv_uploads/admin_views_csv_upload_spec.rb
+++ b/spec/system/csv_uploads/admin_views_csv_upload_spec.rb
@@ -1,7 +1,16 @@
 require "rails_helper"
 
-describe "Admin views CsvUpload" do
+describe "Admin views csv upload" do
   include_context "admin password matches"
+
+  scenario "from list page" do
+    csv_upload = FactoryBot.create(:csv_upload)
+    visit "/admin/csv_uploads"
+    click_on csv_upload.id.to_s
+    expect(page).to have_css "h1", text: "CSV Upload #{csv_upload.id}"
+    expect(page).to have_css "a", text: "CSV Upload List"
+    expect(current_path).to eq admin_csv_upload_path(csv_upload)
+  end
 
   scenario "views CsvUpload" do
     csv_upload = FactoryBot.create(
@@ -12,8 +21,6 @@ describe "Admin views CsvUpload" do
     )
 
     visit "/admin/csv_uploads/#{csv_upload.id}"
-
-    expect(page).to have_content "CSV Upload #{csv_upload.id}"
 
     actual_values = page.all("tr").map do |table_row|
       table_row.all("td").map(&:text)

--- a/spec/system/csv_uploads/admin_views_csv_uploads_spec.rb
+++ b/spec/system/csv_uploads/admin_views_csv_uploads_spec.rb
@@ -3,10 +3,29 @@ require "rails_helper"
 describe "Admin views CsvUploads" do
   include_context "admin password matches"
 
-  scenario "views CsvUploads" do
+  scenario "from dashboard" do
+    visit "/dashboard"
+    click_on "CSV Uploads"
+    expect(page).to have_css "h1", text: "CSV Uploads"
+    expect(current_path).to eq admin_csv_uploads_path
+  end
+
+  scenario "with no records" do
+    visit "/admin/csv_uploads"
+    expect(page.all("tbody tr").count).to eq 0
+  end
+
+  scenario "with a page of records" do
     FactoryBot.create_list(:csv_upload, 3)
     visit "/admin/csv_uploads"
-    expect(page).to have_css "a", text: "New CSV Upload"
     expect(page.all("tbody tr").count).to eq 3
+    expect(page).to_not have_css "nav.pagination"
+  end
+
+  scenario "with two pages of records" do
+    FactoryBot.create_list(:csv_upload, 4)
+    visit "/admin/csv_uploads"
+    expect(page.all("tbody tr").count).to eq 3
+    expect(page).to have_css "nav.pagination"
   end
 end

--- a/spec/system/gift_ideas/admin_creates_gift_idea_spec.rb
+++ b/spec/system/gift_ideas/admin_creates_gift_idea_spec.rb
@@ -1,6 +1,6 @@
 require "rails_helper"
 
-describe "Admin creates GiftIdea" do
+describe "Admin creates gift idea" do
   include_context "admin password matches"
 
   scenario "from list page" do


### PR DESCRIPTION
This PR fully implements the CRUD pages for CSV Uploads. It matches the style and behavior that I've established with the other admin pages. In terms of functionality all I had to add was the edit and delete paths.