### PR TITLE
Do remaining crud for books

### DIFF
--- a/app/controllers/crud/books_controller.rb
+++ b/app/controllers/crud/books_controller.rb
@@ -4,10 +4,15 @@ class Crud::BooksController < ApplicationController
     Book.order(created_at: :desc).page(params[:page])
   end
 
+  def show
+    redirect_to crud_book_path(Book.random) if params[:id] == "random"
+  end
+
   def create
     if book.save
       EnhanceBookJob.perform_later(book.id)
-      redirect_to edit_crud_book_path(book)
+      flash.notice = "Book created"
+      redirect_to crud_book_path(book)
     else
       flash.alert = book.errors.full_messages
       render :new

--- a/app/controllers/crud/books_controller.rb
+++ b/app/controllers/crud/books_controller.rb
@@ -21,16 +21,17 @@ class Crud::BooksController < ApplicationController
 
   def update
     if book.update(book_params)
-      redirect_to edit_crud_book_path(book)
+      flash.notice = "Book updated"
+      redirect_to crud_book_path(book)
     else
-      flash.alert = book.errors.full_messages
-      render :edit
+      flash.alert = book.errors.full_messages.to_sentence
+      redirect_to edit_crud_book_path(book)
     end
   end
 
   private
 
   def book_params
-    params.require(:book).permit(:finished_on, :isbn)
+    params.require(:book).permit(:finished_on, :isbn, :pages, :title)
   end
 end

--- a/app/controllers/crud/books_controller.rb
+++ b/app/controllers/crud/books_controller.rb
@@ -1,5 +1,8 @@
 class Crud::BooksController < ApplicationController
   expose(:book)
+  expose(:books) do
+    Book.order(created_at: :desc).page(params[:page])
+  end
 
   def create
     if book.save

--- a/app/controllers/crud/books_controller.rb
+++ b/app/controllers/crud/books_controller.rb
@@ -14,8 +14,8 @@ class Crud::BooksController < ApplicationController
       flash.notice = "Book created"
       redirect_to crud_book_path(book)
     else
-      flash.alert = book.errors.full_messages
-      render :new
+      flash.alert = book.errors.full_messages.to_sentence
+      redirect_to new_crud_book_path
     end
   end
 

--- a/app/controllers/crud/books_controller.rb
+++ b/app/controllers/crud/books_controller.rb
@@ -29,6 +29,12 @@ class Crud::BooksController < ApplicationController
     end
   end
 
+  def destroy
+    book.destroy
+    flash.notice = "Book deleted"
+    redirect_to crud_books_path
+  end
+
   private
 
   def book_params

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -17,9 +17,11 @@ class Book < ApplicationRecord
   def table_attrs
     [
       ["ISBN", isbn],
-      ["Finished On", finished_on],
       ["Title", title],
-      ["Pages", pages]
+      ["Pages", pages],
+      ["Finished On", finished_on.to_formatted_s(:long)],
+      ["Created At", created_at.to_formatted_s(:long)],
+      ["Updated At", updated_at.to_formatted_s(:long)]
     ]
   end
 end

--- a/app/views/crud/books/_form.html.haml
+++ b/app/views/crud/books/_form.html.haml
@@ -1,4 +1,0 @@
-= form_with model: [:crud, book] do |form|
-  = form.text_field :isbn, placeholder: "isbn"
-  = form.date_field :finished_on, placeholder: "finished on"
-  = form.button button_label

--- a/app/views/crud/books/_form.html.haml
+++ b/app/views/crud/books/_form.html.haml
@@ -1,4 +1,4 @@
 = form_with model: [:crud, book] do |form|
-  = form.text_field :isbn
-  = form.date_field :finished_on
+  = form.text_field :isbn, placeholder: "isbn"
+  = form.date_field :finished_on, placeholder: "finished on"
   = form.button button_label

--- a/app/views/crud/books/edit.html.haml
+++ b/app/views/crud/books/edit.html.haml
@@ -1,5 +1,10 @@
-%h1 Book #{book.id}
+%h1 Edit Book #{book.id}
 
-= render partial: "attrs_table", locals: { attrs: book.table_attrs }
+%p= link_to "Show Book", crud_book_path(book)
 
-= render "form", book: book, button_label: "update"
+= form_with model: [:crud, book] do |form|
+  = form.text_field :isbn, placeholder: "isbn"
+  = form.text_field :title, placeholder: "title"
+  = form.text_field :pages, placeholder: "pages"
+  = form.date_field :finished_on, placeholder: "finished on"
+  = form.button "update"

--- a/app/views/crud/books/index.html.haml
+++ b/app/views/crud/books/index.html.haml
@@ -1,0 +1,16 @@
+%h1 Books
+
+%table
+  %thead
+    %tr
+      %th ID
+      %th Title
+      %th.text-right Created At
+  %tbody
+    - books.each do |book|
+      %tr
+        %td= book.id
+        %td= book.title
+        %td.text-right= book.created_at.to_formatted_s(:long)
+
+= paginate books

--- a/app/views/crud/books/index.html.haml
+++ b/app/views/crud/books/index.html.haml
@@ -1,5 +1,7 @@
 %h1 Books
 
+%p= link_to "New Book", new_crud_book_path
+
 %p= link_to "Random Book", crud_book_path("random")
 
 %table

--- a/app/views/crud/books/index.html.haml
+++ b/app/views/crud/books/index.html.haml
@@ -1,5 +1,7 @@
 %h1 Books
 
+%p= link_to "Random Book", crud_book_path("random")
+
 %table
   %thead
     %tr
@@ -9,7 +11,7 @@
   %tbody
     - books.each do |book|
       %tr
-        %td= book.id
+        %td= link_to book.id, crud_book_path(book)
         %td= book.title
         %td.text-right= book.created_at.to_formatted_s(:long)
 

--- a/app/views/crud/books/new.html.haml
+++ b/app/views/crud/books/new.html.haml
@@ -2,4 +2,7 @@
 
 %p= link_to "Book List", crud_books_path
 
-= render "form", book: book, button_label: "create"
+= form_with model: [:crud, book] do |form|
+  = form.text_field :isbn, placeholder: "isbn"
+  = form.date_field :finished_on, placeholder: "finished on"
+  = form.button "create"

--- a/app/views/crud/books/new.html.haml
+++ b/app/views/crud/books/new.html.haml
@@ -1,3 +1,5 @@
 %h1 New Book
 
+%p= link_to "Book List", crud_books_path
+
 = render "form", book: book, button_label: "create"

--- a/app/views/crud/books/show.html.haml
+++ b/app/views/crud/books/show.html.haml
@@ -1,0 +1,5 @@
+%h1 Book #{book.id}
+
+%p= link_to "Book List", crud_books_path
+
+= render partial: "attrs_table", locals: { attrs: book.table_attrs }

--- a/app/views/crud/books/show.html.haml
+++ b/app/views/crud/books/show.html.haml
@@ -2,4 +2,6 @@
 
 %p= link_to "Book List", crud_books_path
 
+%p= link_to "Edit Book", edit_crud_book_path(book)
+
 = render partial: "attrs_table", locals: { attrs: book.table_attrs }

--- a/app/views/crud/books/show.html.haml
+++ b/app/views/crud/books/show.html.haml
@@ -4,4 +4,6 @@
 
 %p= link_to "Edit Book", edit_crud_book_path(book)
 
+%p= link_to "Delete Book", crud_book_path(book), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }
+
 = render partial: "attrs_table", locals: { attrs: book.table_attrs }

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -15,7 +15,7 @@
 %p= link_to "Today", today_path
 
 %h2 CRUD Pages
-%p= link_to "Books", new_crud_book_path
+%p= link_to "Books", crud_books_path
 %p= link_to "CSV Uploads", crud_csv_uploads_path
 %p= link_to "Financial Accounts", crud_financial_accounts_path
 %p= link_to "Gift Ideas", crud_gift_ideas_path

--- a/app/views/reading_list/index.html.haml
+++ b/app/views/reading_list/index.html.haml
@@ -15,6 +15,6 @@
   %tbody
     - reading_list.books.each do |book|
       %tr
-        %td= link_to book.title, edit_crud_book_path(book)
+        %td= book.title
         %td.text-right= book.finished_on&.strftime("%m/%d")
         %td.text-right= number_with_delimiter book.pages

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
   end
 
   namespace :crud do
-    resources :books, only: %i[create edit index new show update]
+    resources :books
     resources :csv_uploads
     resources :financial_accounts
     resources :gift_ideas

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
   end
 
   namespace :crud do
-    resources :books, only: %i[create edit new update]
+    resources :books, only: %i[create edit index new update]
     resources :csv_uploads
     resources :financial_accounts
     resources :gift_ideas

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -29,7 +29,7 @@ Rails.application.routes.draw do
   end
 
   namespace :crud do
-    resources :books, only: %i[create edit index new update]
+    resources :books, only: %i[create edit index new show update]
     resources :csv_uploads
     resources :financial_accounts
     resources :gift_ideas

--- a/spec/system/crud/books/admin_creates_book_spec.rb
+++ b/spec/system/crud/books/admin_creates_book_spec.rb
@@ -5,9 +5,13 @@ describe "Admin creates book" do
 
   scenario "creating first book" do
     visit "/crud/books/new"
-    fill_in "book[isbn]", with: "123"
+    fill_in "book[isbn]", with: "abc-123"
     fill_in "book[finished_on]", with: "01/01/2000"
     click_on "create"
+
+    expect(page).to have_css ".notice", text: "Book created"
+
+    book = Book.last
 
     actual_values = page.all("tr").map do |table_row|
       table_row.all("td").map(&:text)
@@ -15,10 +19,12 @@ describe "Admin creates book" do
 
     expect(actual_values).to eq(
       [
-        ["ISBN", "123"],
-        ["Finished On", "2000-01-01"],
+        ["ISBN", "abc-123"],
         ["Title", ""],
-        ["Pages", ""]
+        ["Pages", ""],
+        ["Finished On", book.finished_on.to_formatted_s(:long)],
+        ["Created At", book.created_at.to_formatted_s(:long)],
+        ["Updated At", book.updated_at.to_formatted_s(:long)]
       ]
     )
   end

--- a/spec/system/crud/books/admin_creates_book_spec.rb
+++ b/spec/system/crud/books/admin_creates_book_spec.rb
@@ -3,15 +3,33 @@ require "rails_helper"
 describe "Admin creates book" do
   include_context "admin password matches"
 
-  scenario "creating first book" do
+  scenario "from list page" do
+    visit "/crud/books"
+    click_on "New Book"
+    expect(page).to have_css "h1", text: "New Book"
+    expect(page).to have_css "a", text: "Book List"
+    expect(page).to have_current_path new_crud_book_path
+  end
+
+  scenario "create with errors" do
     visit "/crud/books/new"
-    fill_in "book[isbn]", with: "abc-123"
-    fill_in "book[finished_on]", with: "01/01/2000"
+    click_on "create"
+    expect(page).to have_css ".alert", text: "Isbn can't be blank and Finished on can't be blank"
+    expect(page).to have_current_path new_crud_book_path
+  end
+
+  scenario "create successfully" do
+    visit "/crud/books/new"
+    fill_in "isbn", with: "abc-123"
+    fill_in "finished on", with: "01/01/2000"
     click_on "create"
 
     expect(page).to have_css ".notice", text: "Book created"
 
     book = Book.last
+    expect(page).to have_current_path crud_book_path(book)
+
+    expect(EnhanceBookJob).to have_been_enqueued.with(book.id)
 
     actual_values = page.all("tr").map do |table_row|
       table_row.all("td").map(&:text)
@@ -22,7 +40,7 @@ describe "Admin creates book" do
         ["ISBN", "abc-123"],
         ["Title", ""],
         ["Pages", ""],
-        ["Finished On", book.finished_on.to_formatted_s(:long)],
+        ["Finished On", "January 01, 2000"],
         ["Created At", book.created_at.to_formatted_s(:long)],
         ["Updated At", book.updated_at.to_formatted_s(:long)]
       ]

--- a/spec/system/crud/books/admin_deletes_book_spec.rb
+++ b/spec/system/crud/books/admin_deletes_book_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe "Admin deletes book" do
+  include_context "admin password matches"
+
+  let(:book) { FactoryBot.create(:book) }
+
+  scenario "cancels delete" do
+    visit "/crud/books/#{book.id}"
+
+    dismiss_confirm { click_on "Delete Book" }
+
+    expect(Book.count).to eq 1
+    expect(page).to have_current_path crud_book_path(book)
+  end
+
+  scenario "confirms delete" do
+    visit "/crud/books/#{book.id}"
+
+    accept_confirm { click_on "Delete Book" }
+
+    expect(page).to have_css ".notice", text: "Book deleted"
+
+    expect(Book.count).to eq 0
+    expect(page).to have_current_path crud_books_path
+  end
+end

--- a/spec/system/crud/books/admin_edits_book_spec.rb
+++ b/spec/system/crud/books/admin_edits_book_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe "Admin edits book" do
+  include_context "admin password matches"
+
+  scenario "from show page" do
+    book = FactoryBot.create(:book)
+    visit "/crud/books/#{book.id}"
+    click_on "Edit Book"
+    expect(page).to have_css "h1", text: "Edit Book #{book.id}"
+    expect(page).to have_css "a", text: "Show Book"
+    expect(page).to have_current_path edit_crud_book_path(book)
+  end
+
+  scenario "edit with errors" do
+    book = FactoryBot.create(:book)
+    visit "/crud/books/#{book.id}/edit"
+    fill_in "isbn", with: ""
+    click_on "update"
+    expect(page).to have_css ".alert", text: "Isbn can't be blank"
+  end
+
+  scenario "edit successfully" do
+    book = FactoryBot.create(
+      :book,
+      title: "Whiddling And You"
+    )
+    visit "/crud/books/#{book.id}/edit"
+    fill_in "title", with: "Whittling And You"
+    click_on "update"
+
+    expect(page).to have_css ".notice", text: "Book updated"
+    expect(page).to have_current_path crud_book_path(book)
+    expect(page).to have_css "td", text: "Whittling And You"
+  end
+end

--- a/spec/system/crud/books/admin_views_book_spec.rb
+++ b/spec/system/crud/books/admin_views_book_spec.rb
@@ -1,0 +1,52 @@
+require "rails_helper"
+
+describe "Admin views book" do
+  include_context "admin password matches"
+
+  scenario "from list page" do
+    book = FactoryBot.create(:book)
+    visit "/crud/books"
+    click_on book.id.to_s
+    expect(page).to have_css "h1", text: "Book #{book.id}"
+    expect(page).to have_css "a", text: "Book List"
+    expect(page).to have_current_path crud_book_path(book)
+  end
+
+  scenario "viewing a record" do
+    book = FactoryBot.create(
+      :book,
+      finished_on: Date.today,
+      isbn: "abc-123",
+      pages: 777,
+      title: "Whittling And You"
+    )
+
+    visit "/crud/books/#{book.id}"
+
+    actual_values = page.all("tr").map do |table_row|
+      table_row.all("td").map(&:text)
+    end
+
+    expect(actual_values).to eq(
+      [
+        ["ISBN", "abc-123"],
+        ["Title", "Whittling And You"],
+        ["Pages", "777"],
+        ["Finished On", book.finished_on.to_formatted_s(:long)],
+        ["Created At", book.created_at.to_formatted_s(:long)],
+        ["Updated At", book.updated_at.to_formatted_s(:long)]
+      ]
+    )
+  end
+
+  scenario "views random record" do
+    book = FactoryBot.create(:book)
+    expect(Book).to receive(:random).and_return(book)
+
+    visit "/crud/books"
+    click_on "Random Book"
+
+    expect(page).to have_css "h1", text: "Book #{book.id}"
+    expect(page).to have_current_path crud_book_path(book)
+  end
+end

--- a/spec/system/crud/books/admin_views_books_spec.rb
+++ b/spec/system/crud/books/admin_views_books_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe "Admin views books" do
+  include_context "admin password matches"
+
+  scenario "from dashboard" do
+    visit "/dashboard"
+    click_on "Books"
+    expect(page).to have_css "h1", text: "Books"
+    expect(page).to have_current_path crud_books_path
+  end
+
+  scenario "with no records" do
+    visit "/crud/books"
+    expect(page.all("tbody tr").count).to eq 0
+  end
+
+  scenario "with a page of records" do
+    FactoryBot.create_list(:book, 3)
+    visit "/crud/books"
+    expect(page.all("tbody tr").count).to eq 3
+    expect(page).to_not have_css "nav.pagination"
+  end
+
+  scenario "with two pages of records" do
+    FactoryBot.create_list(:book, 4)
+    visit "/crud/books"
+    expect(page.all("tbody tr").count).to eq 3
+    expect(page).to have_css "nav.pagination"
+  end
+end


### PR DESCRIPTION
This PR adds the missing bits for CRUD operations for Book records. I already had a partial create spec and the edit functionality was mostly there but not even tested so the work was to apply the patterns from other models and clean things up.