### PR TITLE
Add crud pages for projects

### DIFF
--- a/app/assets/stylesheets/application.tailwind.css
+++ b/app/assets/stylesheets/application.tailwind.css
@@ -47,6 +47,7 @@
   }
 
   input[type='date'],
+  input[type='datetime-local'],
   input[type='file'],
   input[type='password'],
   input[type='text'],
@@ -69,12 +70,14 @@
   }
 
   input:focus[type='date'],
+  input:focus[type='datetime-local'],
   input:focus[type='file'],
   input:focus[type='password'],
   input:focus[type='text'],
   select:focus,
   textarea:focus,
   input:hover[type='date'],
+  input:hover[type='datetime-local'],
   input:hover[type='file'],
   input:hover[type='password'],
   input:hover[type='text'],

--- a/app/controllers/crud/projects_controller.rb
+++ b/app/controllers/crud/projects_controller.rb
@@ -1,0 +1,42 @@
+class Crud::ProjectsController < ApplicationController
+  expose(:project)
+  expose(:projects) do
+    Project.order(created_at: :desc).page(params[:page])
+  end
+
+  def show
+    redirect_to crud_project_path(Project.random) if params[:id] == "random"
+  end
+
+  def create
+    if project.save
+      flash.notice = "Project created"
+      redirect_to crud_project_path(project)
+    else
+      flash.alert = project.errors.full_messages.to_sentence
+      redirect_to new_crud_project_path
+    end
+  end
+
+  def update
+    if project.update(project_params)
+      flash.notice = "Project updated"
+      redirect_to crud_project_path(project)
+    else
+      flash.alert = project.errors.full_messages.to_sentence
+      redirect_to edit_crud_project_path(project)
+    end
+  end
+
+  def destroy
+    project.destroy
+    flash.notice = "Project deleted"
+    redirect_to crud_projects_path
+  end
+
+  private
+
+  def project_params
+    params.require(:project).permit(:name, :touched_at)
+  end
+end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -19,9 +19,9 @@ class Book < ApplicationRecord
       ["ISBN", isbn],
       ["Title", title],
       ["Pages", pages],
-      ["Finished On", finished_on.to_formatted_s(:long)],
-      ["Created At", created_at.to_formatted_s(:long)],
-      ["Updated At", updated_at.to_formatted_s(:long)]
+      ["Finished On", finished_on.to_fs],
+      ["Created At", created_at.to_fs],
+      ["Updated At", updated_at.to_fs]
     ]
   end
 end

--- a/app/models/csv_upload.rb
+++ b/app/models/csv_upload.rb
@@ -13,8 +13,8 @@ class CsvUpload < ApplicationRecord
     [
       ["Parser Class Name", parser_class_name],
       ["Original Filename", original_filename],
-      ["Created At", created_at.to_formatted_s(:long)],
-      ["Updated At", updated_at.to_formatted_s(:long)]
+      ["Created At", created_at.to_fs],
+      ["Updated At", updated_at.to_fs]
     ]
   end
 end

--- a/app/models/financial_account.rb
+++ b/app/models/financial_account.rb
@@ -20,8 +20,8 @@ class FinancialAccount < ApplicationRecord
   def table_attrs
     [
       ["Name", name],
-      ["Created At", created_at.to_formatted_s(:long)],
-      ["Updated At", updated_at.to_formatted_s(:long)]
+      ["Created At", created_at.to_fs],
+      ["Updated At", updated_at.to_fs]
     ]
   end
 end

--- a/app/models/gift_idea.rb
+++ b/app/models/gift_idea.rb
@@ -11,8 +11,8 @@ class GiftIdea < ApplicationRecord
       ["Title", title],
       ["Website URL", website_url],
       ["Note", note],
-      ["Created At", created_at.to_formatted_s(:long)],
-      ["Updated At", updated_at.to_formatted_s(:long)]
+      ["Created At", created_at.to_fs],
+      ["Updated At", updated_at.to_fs]
     ]
   end
 end

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,5 +1,14 @@
 class Project < ApplicationRecord
-  validates :name, uniqueness: true
+  validates :name, presence: true, uniqueness: true
+
+  def table_attrs
+    [
+      ["Name", name],
+      ["Touched At", touched_at&.to_formatted_s(:long)],
+      ["Created At", created_at.to_formatted_s(:long)],
+      ["Updated At", updated_at.to_formatted_s(:long)]
+    ]
+  end
 
   def as_json(_options = {})
     json = super(only: %i[id name touched_at])

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -4,9 +4,9 @@ class Project < ApplicationRecord
   def table_attrs
     [
       ["Name", name],
-      ["Touched At", touched_at&.to_formatted_s(:long)],
-      ["Created At", created_at.to_formatted_s(:long)],
-      ["Updated At", updated_at.to_formatted_s(:long)]
+      ["Touched At", touched_at&.to_fs],
+      ["Created At", created_at.to_fs],
+      ["Updated At", updated_at.to_fs]
     ]
   end
 

--- a/app/models/work_week.rb
+++ b/app/models/work_week.rb
@@ -26,7 +26,7 @@ class WorkWeek
   def date_span
     monday = dates.first
     friday = dates.last
-    (monday..friday).to_formatted_s(:date_span)
+    (monday..friday).to_fs(:date_span)
   end
 
   def target_date

--- a/app/views/crud/books/index.html.haml
+++ b/app/views/crud/books/index.html.haml
@@ -15,6 +15,6 @@
       %tr
         %td= link_to book.id, crud_book_path(book)
         %td= book.title
-        %td.text-right= book.created_at.to_formatted_s(:long)
+        %td.text-right= book.created_at.to_fs
 
 = paginate books

--- a/app/views/crud/csv_uploads/index.html.haml
+++ b/app/views/crud/csv_uploads/index.html.haml
@@ -17,6 +17,6 @@
         %td= link_to csv_upload.id, crud_csv_upload_path(csv_upload.id)
         %td= csv_upload.parser_class_name
         %td= csv_upload.original_filename
-        %td.text-right= csv_upload.created_at.to_formatted_s(:long)
+        %td.text-right= csv_upload.created_at.to_fs
 
 = paginate csv_uploads

--- a/app/views/crud/financial_accounts/index.html.haml
+++ b/app/views/crud/financial_accounts/index.html.haml
@@ -15,6 +15,6 @@
       %tr
         %td= link_to financial_account.id, crud_financial_account_path(financial_account)
         %td= financial_account.name
-        %td.text-right= financial_account.created_at.to_formatted_s(:long)
+        %td.text-right= financial_account.created_at.to_fs
 
 = paginate financial_accounts

--- a/app/views/crud/gift_ideas/index.html.haml
+++ b/app/views/crud/gift_ideas/index.html.haml
@@ -15,6 +15,6 @@
       %tr
         %td= link_to gift_idea.id, crud_gift_idea_path(gift_idea)
         %td= gift_idea.title
-        %td.text-right= gift_idea.created_at.to_formatted_s(:long)
+        %td.text-right= gift_idea.created_at.to_fs
 
 = paginate gift_ideas

--- a/app/views/crud/projects/_form.html.haml
+++ b/app/views/crud/projects/_form.html.haml
@@ -1,0 +1,4 @@
+= form_with model: [:crud, project] do |form|
+  = form.text_field :name, placeholder: "name"
+  = form.datetime_local_field :touched_at, placeholder: "touched at"
+  = form.button button_label

--- a/app/views/crud/projects/edit.html.haml
+++ b/app/views/crud/projects/edit.html.haml
@@ -1,0 +1,5 @@
+%h1 Edit Project #{project.id}
+
+%p= link_to "Show Project", crud_project_path(project)
+
+= render "form", project: project, button_label: "update"

--- a/app/views/crud/projects/index.html.haml
+++ b/app/views/crud/projects/index.html.haml
@@ -15,6 +15,6 @@
       %tr
         %td= link_to project.id, crud_project_path(project)
         %td= project.name
-        %td.text-right= project.created_at.to_formatted_s(:long)
+        %td.text-right= project.created_at.to_fs
 
 = paginate projects

--- a/app/views/crud/projects/index.html.haml
+++ b/app/views/crud/projects/index.html.haml
@@ -1,0 +1,20 @@
+%h1 Projects
+
+%p= link_to "New Project", new_crud_project_path
+
+%p= link_to "Random Project", crud_project_path("random")
+
+%table
+  %thead
+    %tr
+      %th ID
+      %th Name
+      %th.text-right Created At
+  %tbody
+    - projects.each do |project|
+      %tr
+        %td= link_to project.id, crud_project_path(project)
+        %td= project.name
+        %td.text-right= project.created_at.to_formatted_s(:long)
+
+= paginate projects

--- a/app/views/crud/projects/new.html.haml
+++ b/app/views/crud/projects/new.html.haml
@@ -1,0 +1,5 @@
+%h1 New Project
+
+%p= link_to "Project List", crud_projects_path
+
+= render "form", project: project, button_label: "create"

--- a/app/views/crud/projects/show.html.haml
+++ b/app/views/crud/projects/show.html.haml
@@ -1,0 +1,9 @@
+%h1 Project #{project.id}
+
+%p= link_to "Project List", crud_projects_path
+
+%p= link_to "Edit Project", edit_crud_project_path(project)
+
+%p= link_to "Delete Project", crud_project_path(project), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }
+
+= render partial: "attrs_table", locals: { attrs: project.table_attrs }

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -21,6 +21,7 @@
 %p= link_to "Financial Accounts", crud_financial_accounts_path
 %p= link_to "Gift Ideas", crud_gift_ideas_path
 %p= link_to "Post Bin", crud_post_bin_requests_path
+%p= link_to "Projects", crud_projects_path
 
 %h2 Api Routes
 %p= link_to "Ping", api_v1_ping_path

--- a/app/views/static/form.html.haml
+++ b/app/views/static/form.html.haml
@@ -7,6 +7,7 @@
   %input(type="text" placeholder="name" autofocus="true")
   %input(type="text" placeholder="email")
   %input(type="date")
+  %input(type="datetime-local")
   %textarea(placeholder="write a note")
   %input(type="password" placeholder="password")
   %input(required="true" type="file")

--- a/config/initializers/date_formats.rb
+++ b/config/initializers/date_formats.rb
@@ -1,4 +1,6 @@
-Date::DATE_FORMATS[:standard] = "%m/%d/%Y"
+Date::DATE_FORMATS[:default] = "%m/%d/%Y"
+
+Time::DATE_FORMATS[:default] = "%m/%d/%Y %I:%M:%S%P"
 
 Range::RANGE_FORMATS[:date_span] = proc do |start, stop|
   same_year = start.year == stop.year

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -38,6 +38,7 @@ Rails.application.routes.draw do
     resources :gift_ideas
     resources :hooks, only: %i[create edit index]
     resources :post_bin_requests, only: %i[index show]
+    resources :projects
     resources :raw_hooks, only: %i[show]
   end
 

--- a/db/migrate/20240313023125_add_not_null_to_name_on_projects.rb
+++ b/db/migrate/20240313023125_add_not_null_to_name_on_projects.rb
@@ -1,0 +1,5 @@
+class AddNotNullToNameOnProjects < ActiveRecord::Migration[7.1]
+  def change
+    change_column_null :projects, :name, false
+  end
+end

--- a/spec/factories/project.rb
+++ b/spec/factories/project.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :project do
-    name { "Foo Project" }
+    sequence(:name) { |n| "Foo Project #{n}" }
     touched_at { Time.zone.now }
   end
 end

--- a/spec/models/project_spec.rb
+++ b/spec/models/project_spec.rb
@@ -2,6 +2,11 @@ require "rails_helper"
 
 describe Project do
   describe "validation" do
+    it "is invalid without a name" do
+      project = Project.create name: nil
+      expect(project).to_not be_valid
+    end
+
     it "is valid with unique name" do
       project = Project.create name: "unique"
       expect(project).to be_valid

--- a/spec/system/crud/books/admin_creates_book_spec.rb
+++ b/spec/system/crud/books/admin_creates_book_spec.rb
@@ -40,9 +40,9 @@ describe "Admin creates book" do
         ["ISBN", "abc-123"],
         ["Title", ""],
         ["Pages", ""],
-        ["Finished On", "January 01, 2000"],
-        ["Created At", book.created_at.to_formatted_s(:long)],
-        ["Updated At", book.updated_at.to_formatted_s(:long)]
+        ["Finished On", "01/01/2000"],
+        ["Created At", book.created_at.to_fs],
+        ["Updated At", book.updated_at.to_fs]
       ]
     )
   end

--- a/spec/system/crud/books/admin_views_book_spec.rb
+++ b/spec/system/crud/books/admin_views_book_spec.rb
@@ -32,9 +32,9 @@ describe "Admin views book" do
         ["ISBN", "abc-123"],
         ["Title", "Whittling And You"],
         ["Pages", "777"],
-        ["Finished On", book.finished_on.to_formatted_s(:long)],
-        ["Created At", book.created_at.to_formatted_s(:long)],
-        ["Updated At", book.updated_at.to_formatted_s(:long)]
+        ["Finished On", book.finished_on.to_fs],
+        ["Created At", book.created_at.to_fs],
+        ["Updated At", book.updated_at.to_fs]
       ]
     )
   end

--- a/spec/system/crud/csv_uploads/admin_creates_csv_upload_spec.rb
+++ b/spec/system/crud/csv_uploads/admin_creates_csv_upload_spec.rb
@@ -58,8 +58,8 @@ describe "Admin creates csv upload" do
       [
         ["Parser Class Name", "WellsFargoParser"],
         ["Original Filename", "one_wf_transaction.csv"],
-        ["Created At", csv_upload.created_at.to_formatted_s(:long)],
-        ["Updated At", csv_upload.updated_at.to_formatted_s(:long)]
+        ["Created At", csv_upload.created_at.to_fs],
+        ["Updated At", csv_upload.updated_at.to_fs]
       ]
     )
   end

--- a/spec/system/crud/csv_uploads/admin_views_csv_upload_spec.rb
+++ b/spec/system/crud/csv_uploads/admin_views_csv_upload_spec.rb
@@ -30,8 +30,8 @@ describe "Admin views csv upload" do
       [
         ["Parser Class Name", "DummyParser"],
         ["Original Filename", "dummy-data.csv"],
-        ["Created At", csv_upload.created_at.to_formatted_s(:long)],
-        ["Updated At", csv_upload.updated_at.to_formatted_s(:long)]
+        ["Created At", csv_upload.created_at.to_fs],
+        ["Updated At", csv_upload.updated_at.to_fs]
       ]
     )
 

--- a/spec/system/crud/financial_accounts/admin_creates_financial_account_spec.rb
+++ b/spec/system/crud/financial_accounts/admin_creates_financial_account_spec.rb
@@ -35,8 +35,8 @@ describe "Admin creates financial account" do
     expect(actual_values).to eq(
       [
         ["Name", "Brand new account"],
-        ["Created At", financial_account.created_at.to_formatted_s(:long)],
-        ["Updated At", financial_account.updated_at.to_formatted_s(:long)]
+        ["Created At", financial_account.created_at.to_fs],
+        ["Updated At", financial_account.updated_at.to_fs]
       ]
     )
   end

--- a/spec/system/crud/financial_accounts/admin_views_financial_account_spec.rb
+++ b/spec/system/crud/financial_accounts/admin_views_financial_account_spec.rb
@@ -27,8 +27,8 @@ describe "Admin views financial account" do
     expect(actual_values).to eq(
       [
         ["Name", "Slush fund"],
-        ["Created At", financial_account.created_at.to_formatted_s(:long)],
-        ["Updated At", financial_account.updated_at.to_formatted_s(:long)]
+        ["Created At", financial_account.created_at.to_fs],
+        ["Updated At", financial_account.updated_at.to_fs]
       ]
     )
   end

--- a/spec/system/crud/gift_ideas/admin_creates_gift_idea_spec.rb
+++ b/spec/system/crud/gift_ideas/admin_creates_gift_idea_spec.rb
@@ -39,8 +39,8 @@ describe "Admin creates gift idea" do
         ["Title", "New Mario Game"],
         ["Website URL", "https://www.nintendo.com/new-mario-game"],
         ["Note", "Please get me the actual physical game, thanks!"],
-        ["Created At", gift_idea.created_at.to_formatted_s(:long)],
-        ["Updated At", gift_idea.updated_at.to_formatted_s(:long)]
+        ["Created At", gift_idea.created_at.to_fs],
+        ["Updated At", gift_idea.updated_at.to_fs]
       ]
     )
   end

--- a/spec/system/crud/gift_ideas/admin_views_gift_idea_spec.rb
+++ b/spec/system/crud/gift_ideas/admin_views_gift_idea_spec.rb
@@ -31,8 +31,8 @@ describe "Admin views gift idea" do
         ["Title", "New Mario Game"],
         ["Website URL", "https://www.nintendo.com/new-mario-game"],
         ["Note", "Please get me the actual physical game, thanks!"],
-        ["Created At", gift_idea.created_at.to_formatted_s(:long)],
-        ["Updated At", gift_idea.updated_at.to_formatted_s(:long)]
+        ["Created At", gift_idea.created_at.to_fs],
+        ["Updated At", gift_idea.updated_at.to_fs]
       ]
     )
   end

--- a/spec/system/crud/projects/admin_creates_project_spec.rb
+++ b/spec/system/crud/projects/admin_creates_project_spec.rb
@@ -1,0 +1,44 @@
+require "rails_helper"
+
+describe "Admin creates project" do
+  include_context "admin password matches"
+
+  scenario "from list page" do
+    visit "/crud/projects"
+    click_on "New Project"
+    expect(page).to have_css "h1", text: "New Project"
+    expect(page).to have_css "a", text: "Project List"
+    expect(page).to have_current_path new_crud_project_path
+  end
+
+  scenario "create with errors" do
+    visit "/crud/projects/new"
+    click_on "create"
+    expect(page).to have_css ".alert", text: "Name can't be blank"
+    expect(page).to have_current_path new_crud_project_path
+  end
+
+  scenario "create successfully" do
+    visit "/crud/projects/new"
+    fill_in "name", with: "Yet Another Ruby Gem"
+    click_on "create"
+
+    expect(page).to have_css ".notice", text: "Project created"
+
+    project = Project.last
+    expect(page).to have_current_path crud_project_path(project)
+
+    actual_values = page.all("tr").map do |table_row|
+      table_row.all("td").map(&:text)
+    end
+
+    expect(actual_values).to eq(
+      [
+        ["Name", "Yet Another Ruby Gem"],
+        ["Touched At", ""],
+        ["Created At", project.created_at.to_formatted_s(:long)],
+        ["Updated At", project.updated_at.to_formatted_s(:long)]
+      ]
+    )
+  end
+end

--- a/spec/system/crud/projects/admin_creates_project_spec.rb
+++ b/spec/system/crud/projects/admin_creates_project_spec.rb
@@ -36,8 +36,8 @@ describe "Admin creates project" do
       [
         ["Name", "Yet Another Ruby Gem"],
         ["Touched At", ""],
-        ["Created At", project.created_at.to_formatted_s(:long)],
-        ["Updated At", project.updated_at.to_formatted_s(:long)]
+        ["Created At", project.created_at.to_fs],
+        ["Updated At", project.updated_at.to_fs]
       ]
     )
   end

--- a/spec/system/crud/projects/admin_deletes_project_spec.rb
+++ b/spec/system/crud/projects/admin_deletes_project_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe "Admin deletes project" do
+  include_context "admin password matches"
+
+  let(:project) { FactoryBot.create(:project) }
+
+  scenario "cancels delete" do
+    visit "/crud/projects/#{project.id}"
+
+    dismiss_confirm { click_on "Delete Project" }
+
+    expect(Project.count).to eq 1
+    expect(page).to have_current_path crud_project_path(project)
+  end
+
+  scenario "confirms delete" do
+    visit "/crud/projects/#{project.id}"
+
+    accept_confirm { click_on "Delete Project" }
+
+    expect(page).to have_css ".notice", text: "Project deleted"
+
+    expect(Project.count).to eq 0
+    expect(page).to have_current_path crud_projects_path
+  end
+end

--- a/spec/system/crud/projects/admin_edits_project_spec.rb
+++ b/spec/system/crud/projects/admin_edits_project_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe "Admin edits project" do
+  include_context "admin password matches"
+
+  scenario "from show page" do
+    project = FactoryBot.create(:project)
+    visit "/crud/projects/#{project.id}"
+    click_on "Edit Project"
+    expect(page).to have_css "h1", text: "Edit Project #{project.id}"
+    expect(page).to have_css "a", text: "Show Project"
+    expect(page).to have_current_path edit_crud_project_path(project)
+  end
+
+  scenario "edit with errors" do
+    project = FactoryBot.create(:project)
+    visit "/crud/projects/#{project.id}/edit"
+    fill_in "name", with: ""
+    click_on "update"
+    expect(page).to have_css ".alert", text: "Name can't be blank"
+  end
+
+  scenario "edit successfully" do
+    project = FactoryBot.create(
+      :project,
+      name: "Yet Another Rooby Gem"
+    )
+    visit "/crud/projects/#{project.id}/edit"
+    fill_in "name", with: "Yet Another Ruby Gem"
+    click_on "update"
+
+    expect(page).to have_css ".notice", text: "Project updated"
+    expect(page).to have_current_path crud_project_path(project)
+    expect(page).to have_css "td", text: "Yet Another Ruby Gem"
+  end
+end

--- a/spec/system/crud/projects/admin_views_project_spec.rb
+++ b/spec/system/crud/projects/admin_views_project_spec.rb
@@ -28,9 +28,9 @@ describe "Admin views project" do
     expect(actual_values).to eq(
       [
         ["Name", "Yet Another Ruby Gem"],
-        ["Touched At", project.touched_at.to_formatted_s(:long)],
-        ["Created At", project.created_at.to_formatted_s(:long)],
-        ["Updated At", project.updated_at.to_formatted_s(:long)]
+        ["Touched At", project.touched_at.to_fs],
+        ["Created At", project.created_at.to_fs],
+        ["Updated At", project.updated_at.to_fs]
       ]
     )
   end

--- a/spec/system/crud/projects/admin_views_project_spec.rb
+++ b/spec/system/crud/projects/admin_views_project_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+describe "Admin views project" do
+  include_context "admin password matches"
+
+  scenario "from list page" do
+    project = FactoryBot.create(:project)
+    visit "/crud/projects"
+    click_on project.id.to_s
+    expect(page).to have_css "h1", text: "Project #{project.id}"
+    expect(page).to have_css "a", text: "Project List"
+    expect(page).to have_current_path crud_project_path(project)
+  end
+
+  scenario "viewing a record" do
+    project = FactoryBot.create(
+      :project,
+      name: "Yet Another Ruby Gem",
+      touched_at: Time.now
+    )
+
+    visit "/crud/projects/#{project.id}"
+
+    actual_values = page.all("tr").map do |table_row|
+      table_row.all("td").map(&:text)
+    end
+
+    expect(actual_values).to eq(
+      [
+        ["Name", "Yet Another Ruby Gem"],
+        ["Touched At", project.touched_at.to_formatted_s(:long)],
+        ["Created At", project.created_at.to_formatted_s(:long)],
+        ["Updated At", project.updated_at.to_formatted_s(:long)]
+      ]
+    )
+  end
+
+  scenario "views random record" do
+    project = FactoryBot.create(:project)
+    expect(Project).to receive(:random).and_return(project)
+
+    visit "/crud/projects"
+    click_on "Random Project"
+
+    expect(page).to have_css "h1", text: "Project #{project.id}"
+    expect(page).to have_current_path crud_project_path(project)
+  end
+end

--- a/spec/system/crud/projects/admin_views_projects_spec.rb
+++ b/spec/system/crud/projects/admin_views_projects_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe "Admin views projects" do
+  include_context "admin password matches"
+
+  scenario "from dashboard" do
+    visit "/dashboard"
+    click_on "Projects"
+    expect(page).to have_css "h1", text: "Projects"
+    expect(page).to have_current_path crud_projects_path
+  end
+
+  scenario "with no records" do
+    visit "/crud/projects"
+    expect(page.all("tbody tr").count).to eq 0
+  end
+
+  scenario "with a page of records" do
+    FactoryBot.create_list(:project, 3)
+    visit "/crud/projects"
+    expect(page.all("tbody tr").count).to eq 3
+    expect(page).to_not have_css "nav.pagination"
+  end
+
+  scenario "with two pages of records" do
+    FactoryBot.create_list(:project, 4)
+    visit "/crud/projects"
+    expect(page.all("tbody tr").count).to eq 3
+    expect(page).to have_css "nav.pagination"
+  end
+end


### PR DESCRIPTION
This PR adds proper CRUD pages for `Project` records but along the way I did a couple other nice things:

* added support for input fields that accept date and time by updating styles
* configured the default format of dates and times correctly
* used this configuration to better display dates and times