### PR TITLE
Update bucket for active storage

### DIFF
--- a/config/storage.yml
+++ b/config/storage.yml
@@ -11,4 +11,4 @@ amazon:
   access_key_id: <%= Monolithium.config.aws_access_key %>
   secret_access_key: <%= Monolithium.config.aws_secret_key %>
   region: <%= Monolithium.config.aws_region %>
-  bucket: mli-data
+  bucket: mli-active-storage


### PR DESCRIPTION
Turns out you really want a completely separate bucket for ActiveStorage because it just dumps all of the files right into the root of the bucket. 😬 