### PR TITLE
Add nicer list of fuzzies

### DIFF
--- a/app/controllers/fuzzies_controller.rb
+++ b/app/controllers/fuzzies_controller.rb
@@ -1,0 +1,6 @@
+class FuzziesController < ApplicationController
+  expose(:fuzzies) do
+    ids = WarmFuzzy.all.pluck(:id).sample(10)
+    WarmFuzzy.find(ids)
+  end
+end

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -3,6 +3,7 @@
 %h2 Public Pages
 %p= link_to "Artsy Viewer", artsy_viewer_path
 %p= link_to "Fairing Direball", faring_direball_path
+%p= link_to "Fuzzies", fuzzies_path
 %p= link_to "Reading List", reading_list_path(year: Time.now.year)
 %p= link_to "Root", root_path
 %p= link_to "Style Pages", article_styles_path

--- a/app/views/fuzzies/index.html.haml
+++ b/app/views/fuzzies/index.html.haml
@@ -1,0 +1,11 @@
+%h1 Fuzzies
+
+- fuzzies.each do |fuzzy|
+  %h2.mb-0= fuzzy.title
+  %p from #{fuzzy.author} on #{fuzzy.received_at.to_fs}
+  - if fuzzy.body
+    %blockquote
+      :markdown
+        #{fuzzy.body}
+  - if fuzzy.screenshot.representable?
+    = image_tag fuzzy.screenshot

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -4,6 +4,7 @@ Rails.application.routes.draw do
   get "dashboard", to: "dashboard#show"
   get "faring_direball", to: "faring_direball#index"
   get "financial_reports/:year", to: "financial_reports#show", as: :financial_report
+  get "fuzzies", to: "fuzzies#index", as: :fuzzies
   get "model_counts", to: "model_counts#index", as: :model_counts
   get "reading-list/:year", to: "reading_list#index", as: :reading_list
   get "today", to: "today#show", as: :today

--- a/spec/system/fuzzies/admin_views_fuzzies_spec.rb
+++ b/spec/system/fuzzies/admin_views_fuzzies_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+describe "Admin views fuzzies" do
+  include_context "admin password matches"
+
+  scenario "from dashboard" do
+    visit "/dashboard"
+    click_on "Fuzzies"
+    expect(page).to have_css "h1", text: "Fuzzies"
+    expect(page).to have_current_path fuzzies_path
+  end
+
+  scenario "with some records" do
+    warm_fuzzies = FactoryBot.create_list(:warm_fuzzy, 3)
+    visit "/fuzzies"
+    warm_fuzzies.each do |warm_fuzzy|
+      expect(page).to have_css "h2", text: warm_fuzzy.title
+      expect(page).to have_content warm_fuzzy.author
+      expect(page).to have_content warm_fuzzy.received_at.to_fs
+      expect(page).to have_css "blockquote", text: warm_fuzzy.body
+    end
+  end
+end


### PR DESCRIPTION
Over on #181 I added the CRUD around my WarmFuzzy records but I wanted something a little nicer for actually reading through them. This PR implements a list where I pick a random sample of 10 and display them in a more friendly format.