### PR TITLE
Add crud for cybertail models

### DIFF
--- a/app/controllers/crud/raw_hooks_controller.rb
+++ b/app/controllers/crud/raw_hooks_controller.rb
@@ -1,3 +1,42 @@
 class Crud::RawHooksController < ApplicationController
   expose(:raw_hook)
+  expose(:raw_hooks) do
+    RawHook.order(created_at: :desc).page(params[:page])
+  end
+
+  def show
+    redirect_to crud_raw_hook_path(RawHook.random) if params[:id] == "random"
+  end
+
+  def create
+    if raw_hook.save
+      flash.notice = "Raw Hook created"
+      redirect_to crud_raw_hook_path(raw_hook)
+    else
+      flash.alert = raw_hook.errors.full_messages.to_sentence
+      redirect_to new_crud_raw_hook_path
+    end
+  end
+
+  def update
+    if raw_hook.update(raw_hook_params)
+      flash.notice = "Raw Hook updated"
+      redirect_to crud_raw_hook_path(raw_hook)
+    else
+      flash.alert = raw_hook.errors.full_messages.to_sentence
+      redirect_to edit_crud_raw_hook_path(raw_hook)
+    end
+  end
+
+  def destroy
+    raw_hook.destroy
+    flash.notice = "Raw Hook deleted"
+    redirect_to crud_raw_hooks_path
+  end
+
+  private
+
+  def raw_hook_params
+    params.require(:raw_hook).permit(:body, :headers, :params)
+  end
 end

--- a/app/controllers/crud/webhook_senders_controller.rb
+++ b/app/controllers/crud/webhook_senders_controller.rb
@@ -1,0 +1,42 @@
+class Crud::WebhookSendersController < ApplicationController
+  expose(:webhook_sender)
+  expose(:webhook_senders) do
+    WebhookSender.order(created_at: :desc).page(params[:page])
+  end
+
+  def show
+    redirect_to crud_webhook_sender_path(WebhookSender.random) if params[:id] == "random"
+  end
+
+  def create
+    if webhook_sender.save
+      flash.notice = "Webhook Sender created"
+      redirect_to crud_webhook_sender_path(webhook_sender)
+    else
+      flash.alert = webhook_sender.errors.full_messages.to_sentence
+      redirect_to new_crud_webhook_sender_path
+    end
+  end
+
+  def update
+    if webhook_sender.update(webhook_sender_params)
+      flash.notice = "Webhook Sender updated"
+      redirect_to crud_webhook_sender_path(webhook_sender)
+    else
+      flash.alert = webhook_sender.errors.full_messages.to_sentence
+      redirect_to edit_crud_webhook_sender_path(webhook_sender)
+    end
+  end
+
+  def destroy
+    webhook_sender.destroy
+    flash.notice = "Webhook Sender deleted"
+    redirect_to crud_webhook_senders_path
+  end
+
+  private
+
+  def webhook_sender_params
+    params.require(:webhook_sender).permit(:name, :parser)
+  end
+end

--- a/app/models/raw_hook.rb
+++ b/app/models/raw_hook.rb
@@ -1,7 +1,16 @@
 class RawHook < ApplicationRecord
+  validates_presence_of :body, :headers, :params
+
   has_one :hook, dependent: :destroy
 
   after_create_commit :created
+
+  def table_attrs
+    [
+      ["Created At", created_at.to_fs],
+      ["Updated At", updated_at.to_fs]
+    ]
+  end
 
   private
 

--- a/app/models/webhook_sender.rb
+++ b/app/models/webhook_sender.rb
@@ -23,4 +23,13 @@ class WebhookSender < ApplicationRecord
   def logo_name
     "logos/#{name.delete(" ").downcase}-logo@2x.png"
   end
+
+  def table_attrs
+    [
+      ["Name", name],
+      ["Parser", parser],
+      ["Created At", created_at.to_fs],
+      ["Updated At", updated_at.to_fs]
+    ]
+  end
 end

--- a/app/views/crud/raw_hooks/_form.html.haml
+++ b/app/views/crud/raw_hooks/_form.html.haml
@@ -1,0 +1,5 @@
+= form_with model: [:crud, raw_hook] do |form|
+  = form.text_area :body, placeholder: "body"
+  = form.text_area :headers, placeholder: "headers"
+  = form.text_area :params, placeholder: "params"
+  = form.button button_label

--- a/app/views/crud/raw_hooks/edit.html.haml
+++ b/app/views/crud/raw_hooks/edit.html.haml
@@ -1,0 +1,5 @@
+%h1 Edit Raw Hook #{raw_hook.id}
+
+%p= link_to "Show Raw Hook", crud_raw_hook_path(raw_hook)
+
+= render "form", raw_hook: raw_hook, button_label: "update"

--- a/app/views/crud/raw_hooks/index.html.haml
+++ b/app/views/crud/raw_hooks/index.html.haml
@@ -1,0 +1,20 @@
+%h1 Raw Hooks
+
+%p= link_to "New Raw Hook", new_crud_raw_hook_path
+
+%p= link_to "Random Raw Hook", crud_raw_hook_path("random")
+
+%table
+  %thead
+    %tr
+      %th ID
+      %th Body Snippet
+      %th.text-right Created At
+  %tbody
+    - raw_hooks.each do |raw_hook|
+      %tr
+        %td= link_to raw_hook.id, crud_raw_hook_path(raw_hook)
+        %td= raw_hook.body.first(100)
+        %td.text-right= raw_hook.created_at.to_fs
+
+= paginate raw_hooks

--- a/app/views/crud/raw_hooks/new.html.haml
+++ b/app/views/crud/raw_hooks/new.html.haml
@@ -1,0 +1,5 @@
+%h1 New Raw Hook
+
+%p= link_to "Raw Hook List", crud_raw_hooks_path
+
+= render "form", raw_hook: raw_hook, button_label: "create"

--- a/app/views/crud/raw_hooks/show.html.haml
+++ b/app/views/crud/raw_hooks/show.html.haml
@@ -1,16 +1,24 @@
 %h1 Raw Hook #{raw_hook.id}
 
-%p Headers
+%p= link_to "Raw Hook List", crud_raw_hooks_path
+
+%p= link_to "Edit Raw Hook", edit_crud_raw_hook_path(raw_hook)
+
+%p= link_to "Delete Raw Hook", crud_raw_hook_path(raw_hook), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }
+
+= render partial: "attrs_table", locals: { attrs: raw_hook.table_attrs }
+
+%h2 Headers
 
 %pre.text-off-black
   %code= JSON.pretty_generate(raw_hook.headers)
 
-%p Params
+%h2 Params
 
 %pre.text-off-black
   %code= JSON.pretty_generate(raw_hook.params)
 
-%p Body
+%h2 Body
 
 %pre.text-off-black
   %code= raw_hook.body

--- a/app/views/crud/webhook_senders/_form.html.haml
+++ b/app/views/crud/webhook_senders/_form.html.haml
@@ -1,0 +1,4 @@
+= form_with model: [:crud, webhook_sender] do |form|
+  = form.text_field :name, placeholder: "name"
+  = form.text_field :parser, placeholder: "parser"
+  = form.button button_label

--- a/app/views/crud/webhook_senders/edit.html.haml
+++ b/app/views/crud/webhook_senders/edit.html.haml
@@ -1,0 +1,5 @@
+%h1 Edit Webhook Sender #{webhook_sender.id}
+
+%p= link_to "Show Webhook Sender", crud_webhook_sender_path(webhook_sender)
+
+= render "form", webhook_sender: webhook_sender, button_label: "update"

--- a/app/views/crud/webhook_senders/index.html.haml
+++ b/app/views/crud/webhook_senders/index.html.haml
@@ -1,0 +1,20 @@
+%h1 Webhook Senders
+
+%p= link_to "New Webhook Sender", new_crud_webhook_sender_path
+
+%p= link_to "Random Webhook Sender", crud_webhook_sender_path("random")
+
+%table
+  %thead
+    %tr
+      %th ID
+      %th Name
+      %th.text-right Created At
+  %tbody
+    - webhook_senders.each do |webhook_sender|
+      %tr
+        %td= link_to webhook_sender.id, crud_webhook_sender_path(webhook_sender)
+        %td= webhook_sender.name
+        %td.text-right= webhook_sender.created_at.to_fs
+
+= paginate webhook_senders

--- a/app/views/crud/webhook_senders/new.html.haml
+++ b/app/views/crud/webhook_senders/new.html.haml
@@ -1,0 +1,5 @@
+%h1 New Webhook Sender
+
+%p= link_to "Webhook Sender List", crud_webhook_senders_path
+
+= render "form", webhook_sender: webhook_sender, button_label: "create"

--- a/app/views/crud/webhook_senders/show.html.haml
+++ b/app/views/crud/webhook_senders/show.html.haml
@@ -1,0 +1,9 @@
+%h1 Webhook Sender #{webhook_sender.id}
+
+%p= link_to "Webhook Sender List", crud_webhook_senders_path
+
+%p= link_to "Edit Webhook Sender", edit_crud_webhook_sender_path(webhook_sender)
+
+%p= link_to "Delete Webhook Sender", crud_webhook_sender_path(webhook_sender), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }
+
+= render partial: "attrs_table", locals: { attrs: webhook_sender.table_attrs }

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -1,6 +1,7 @@
 %h1 Dashboard
 
 %h2 Public Pages
+
 %p= link_to "Artsy Viewer", artsy_viewer_path
 %p= link_to "Fairing Direball", faring_direball_path
 %p= link_to "Reading List", reading_list_path(year: Time.now.year)
@@ -10,6 +11,7 @@
 %p= link_to "Wishlist", wishlist_path
 
 %h2 Private Pages
+
 %p= link_to "Cybertail", cybertail_path
 %p= link_to "Financial Report", financial_report_path(year: Time.now.year)
 %p= link_to "Fuzzies", fuzzies_path
@@ -18,16 +20,19 @@
 %p= link_to "Today", today_path
 
 %h2 CRUD Pages
+
 %p= link_to "Books", crud_books_path
 %p= link_to "CSV Uploads", crud_csv_uploads_path
 %p= link_to "Financial Accounts", crud_financial_accounts_path
 %p= link_to "Gift Ideas", crud_gift_ideas_path
 %p= link_to "Post Bin", crud_post_bin_requests_path
 %p= link_to "Projects", crud_projects_path
+%p= link_to "Raw Hooks", crud_raw_hooks_path
 %p= link_to "Sneakers", crud_sneakers_path
 %p= link_to "Warm Fuzzies", crud_warm_fuzzies_path
 %p= link_to "Webhook Senders", crud_webhook_senders_path
 
 %h2 Api Routes
+
 %p= link_to "Ping", api_v1_ping_path
 %p= link_to "Word Rot Killswitch", api_v1_word_rot_killswitch_path

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -26,6 +26,7 @@
 %p= link_to "Projects", crud_projects_path
 %p= link_to "Sneakers", crud_sneakers_path
 %p= link_to "Warm Fuzzies", crud_warm_fuzzies_path
+%p= link_to "Webhook Senders", crud_webhook_senders_path
 
 %h2 Api Routes
 %p= link_to "Ping", api_v1_ping_path

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -46,6 +46,7 @@ Rails.application.routes.draw do
     resources :raw_hooks, only: %i[show]
     resources :sneakers
     resources :warm_fuzzies
+    resources :webhook_senders
   end
 
   namespace :api do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -43,7 +43,7 @@ Rails.application.routes.draw do
     resources :hooks, only: %i[create edit index]
     resources :post_bin_requests, only: %i[index show]
     resources :projects
-    resources :raw_hooks, only: %i[show]
+    resources :raw_hooks
     resources :sneakers
     resources :warm_fuzzies
     resources :webhook_senders

--- a/spec/factories/raw_hook.rb
+++ b/spec/factories/raw_hook.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :raw_hook do
-    headers { {} }
-    params { {} }
-    body { "" }
+    headers { {"x-header-key" => "header-value"} }
+    params { {"param-key" => "param-value"} }
+    body { "payload" }
   end
 end

--- a/spec/models/raw_hook_spec.rb
+++ b/spec/models/raw_hook_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+describe RawHook do
+  describe "validation" do
+    context "without required attrs" do
+      it "is invalid" do
+        raw_hook = RawHook.new
+        expect(raw_hook).to_not be_valid
+      end
+    end
+
+    context "with required attrs" do
+      it "is valid" do
+        raw_hook = RawHook.new(
+          body: "foo",
+          headers: {foo: :bar},
+          params: {foo: :bar}
+        )
+
+        expect(raw_hook).to be_valid
+      end
+    end
+  end
+end

--- a/spec/requests/api/v1/raw_hooks_spec.rb
+++ b/spec/requests/api/v1/raw_hooks_spec.rb
@@ -16,6 +16,7 @@ describe "POST /api/v1/raw_hooks" do
       REMOTE_ADDR
       REQUEST_METHOD
       REQUEST_URI
+      RAW_POST_DATA
       SCRIPT_NAME
       SERVER_NAME
       SERVER_PORT
@@ -26,7 +27,8 @@ describe "POST /api/v1/raw_hooks" do
   let(:default_params) do
     {
       "action" => "create",
-      "controller" => "api/v1/raw_hooks"
+      "controller" => "api/v1/raw_hooks",
+      "raw_hook" => {}
     }
   end
 
@@ -34,13 +36,14 @@ describe "POST /api/v1/raw_hooks" do
     let(:headers) { {} }
     let(:params) { {} }
 
-    it "stores default params and headers" do
-      post "/api/v1/raw_hooks", params: params, headers: headers
+    it "stores empty object for body and defaults for params and headers" do
+      post "/api/v1/raw_hooks", params: params, headers: headers, as: :json
 
-      expect(response.status).to be 201
+      expect(response.status).to eq 201
       expect(RawHook.count).to eq 1
 
       raw_hook = RawHook.first
+      expect(raw_hook.body).to eq "{}"
       expect(default_header_keys).to match_array(raw_hook.headers.keys)
       expect(raw_hook.params).to eq default_params
     end
@@ -51,18 +54,20 @@ describe "POST /api/v1/raw_hooks" do
     let(:params) { {string_param: "password", integer_param: 11} }
 
     it "stores those too" do
-      post "/api/v1/raw_hooks", params: params, headers: headers
+      post "/api/v1/raw_hooks", params: params, headers: headers, as: :json
 
-      expect(response.status).to be 201
+      expect(response.status).to eq 201
       expect(RawHook.count).to eq 1
 
       raw_hook = RawHook.first
+
+      expect(raw_hook.body).to eq '{"string_param":"password","integer_param":11}'
 
       expect(raw_hook.headers["HTTP_X_STRING_HEADER"]).to eq "token"
       expect(raw_hook.headers["HTTP_X_INTEGER_HEADER"]).to eq 7
 
       expect(raw_hook.params["string_param"]).to eq "password"
-      expect(raw_hook.params["integer_param"]).to eq "11"
+      expect(raw_hook.params["integer_param"]).to eq 11
     end
   end
 end

--- a/spec/system/crud/raw_hooks/admin_creates_raw_hook_spec.rb
+++ b/spec/system/crud/raw_hooks/admin_creates_raw_hook_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+describe "Admin creates raw hook" do
+  include_context "admin password matches"
+
+  scenario "from list page" do
+    visit "/crud/raw_hooks"
+    click_on "New Raw Hook"
+    expect(page).to have_css "h1", text: "New Raw Hook"
+    expect(page).to have_css "a", text: "Raw Hook List"
+    expect(page).to have_current_path new_crud_raw_hook_path
+  end
+
+  scenario "create with errors" do
+    visit "/crud/raw_hooks/new"
+    click_on "create"
+    expect(page).to have_css ".alert", text: "Body can't be blank, Headers can't be blank, and Params can't be blank"
+    expect(page).to have_current_path new_crud_raw_hook_path
+  end
+
+  scenario "create successfully" do
+    visit "/crud/raw_hooks/new"
+    fill_in "body", with: "payload"
+    fill_in "headers", with: {"x-header-name" => "header-value"}.to_json
+    fill_in "params", with: {"param-name" => "param-value"}.to_json
+    click_on "create"
+
+    expect(page).to have_css ".notice", text: "Raw Hook created"
+
+    raw_hook = RawHook.last
+    expect(page).to have_current_path crud_raw_hook_path(raw_hook)
+
+    actual_values = page.all("tr").map do |table_row|
+      table_row.all("td").map(&:text)
+    end
+
+    expect(actual_values).to eq(
+      [
+        ["Created At", raw_hook.created_at.to_fs],
+        ["Updated At", raw_hook.updated_at.to_fs]
+      ]
+    )
+
+    expect(page.all("h2").map(&:text)).to eq %w[Headers Params Body]
+    expect(page.all("pre code").map(&:text)).to eq(
+      [
+        JSON.pretty_generate(raw_hook.headers),
+        JSON.pretty_generate(raw_hook.params),
+        raw_hook.body
+      ]
+    )
+  end
+end

--- a/spec/system/crud/raw_hooks/admin_deletes_raw_hook_spec.rb
+++ b/spec/system/crud/raw_hooks/admin_deletes_raw_hook_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe "Admin deletes raw hook" do
+  include_context "admin password matches"
+
+  let(:raw_hook) { FactoryBot.create(:raw_hook) }
+
+  scenario "cancels delete" do
+    visit "/crud/raw_hooks/#{raw_hook.id}"
+
+    dismiss_confirm { click_on "Delete Raw Hook" }
+
+    expect(RawHook.count).to eq 1
+    expect(page).to have_current_path crud_raw_hook_path(raw_hook)
+  end
+
+  scenario "confirms delete" do
+    visit "/crud/raw_hooks/#{raw_hook.id}"
+
+    accept_confirm { click_on "Delete Raw Hook" }
+
+    expect(page).to have_css ".notice", text: "Raw Hook deleted"
+
+    expect(RawHook.count).to eq 0
+    expect(page).to have_current_path crud_raw_hooks_path
+  end
+end

--- a/spec/system/crud/raw_hooks/admin_edits_raw_hook_spec.rb
+++ b/spec/system/crud/raw_hooks/admin_edits_raw_hook_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe "Admin edits raw hook" do
+  include_context "admin password matches"
+
+  scenario "from show page" do
+    raw_hook = FactoryBot.create(:raw_hook)
+    visit "/crud/raw_hooks/#{raw_hook.id}"
+    click_on "Edit Raw Hook"
+    expect(page).to have_css "h1", text: "Edit Raw Hook #{raw_hook.id}"
+    expect(page).to have_css "a", text: "Show Raw Hook"
+    expect(page).to have_current_path edit_crud_raw_hook_path(raw_hook)
+  end
+
+  scenario "edit with errors" do
+    raw_hook = FactoryBot.create(:raw_hook)
+    visit "/crud/raw_hooks/#{raw_hook.id}/edit"
+    fill_in "body", with: ""
+    click_on "update"
+    expect(page).to have_css ".alert", text: "Body can't be blank"
+  end
+
+  scenario "edit successfully" do
+    raw_hook = FactoryBot.create(
+      :raw_hook,
+      body: "very lame bayload"
+    )
+    visit "/crud/raw_hooks/#{raw_hook.id}/edit"
+    fill_in "body", with: "very cool payload"
+    click_on "update"
+
+    expect(page).to have_css ".notice", text: "Raw Hook updated"
+    expect(page).to have_current_path crud_raw_hook_path(raw_hook)
+    expect(page).to have_css "pre code", text: "very cool payload"
+  end
+end

--- a/spec/system/crud/raw_hooks/admin_views_raw_hook_spec.rb
+++ b/spec/system/crud/raw_hooks/admin_views_raw_hook_spec.rb
@@ -3,23 +3,54 @@ require "rails_helper"
 describe "Admin views raw hook" do
   include_context "admin password matches"
 
-  scenario "with a valid id" do
+  scenario "from list page" do
+    raw_hook = FactoryBot.create(:raw_hook)
+    visit "/crud/raw_hooks"
+    click_on raw_hook.id.to_s
+    expect(page).to have_css "h1", text: "Raw Hook #{raw_hook.id}"
+    expect(page).to have_css "a", text: "Raw Hook List"
+    expect(page).to have_current_path crud_raw_hook_path(raw_hook)
+  end
+
+  scenario "viewing a record" do
     raw_hook = FactoryBot.create(
       :raw_hook,
-      body: "please parse me!",
-      headers: {"X-Access-Token": "abc123"},
-      params: {key: "value"}
+      body: "payload",
+      headers: {"x-header-name" => "header-value"}.to_json,
+      params: {"param-name" => "param-value"}.to_json
     )
 
     visit "/crud/raw_hooks/#{raw_hook.id}"
 
-    expect(page).to have_css "h1", text: "Raw Hook #{raw_hook.id}"
+    actual_values = page.all("tr").map do |table_row|
+      table_row.all("td").map(&:text)
+    end
 
-    headers_code_tag, params_code_tag, body_code_tag = page.all("code")
-    expect(headers_code_tag.text).to include "X-Access-Token"
-    expect(headers_code_tag.text).to include "abc123"
-    expect(params_code_tag.text).to include "key"
-    expect(params_code_tag.text).to include "value"
-    expect(body_code_tag.text).to include "please parse me!"
+    expect(actual_values).to eq(
+      [
+        ["Created At", raw_hook.created_at.to_fs],
+        ["Updated At", raw_hook.updated_at.to_fs]
+      ]
+    )
+
+    expect(page.all("h2").map(&:text)).to eq %w[Headers Params Body]
+    expect(page.all("pre code").map(&:text)).to eq(
+      [
+        JSON.pretty_generate(raw_hook.headers),
+        JSON.pretty_generate(raw_hook.params),
+        raw_hook.body
+      ]
+    )
+  end
+
+  scenario "views random record" do
+    raw_hook = FactoryBot.create(:raw_hook)
+    expect(RawHook).to receive(:random).and_return(raw_hook)
+
+    visit "/crud/raw_hooks"
+    click_on "Random Raw Hook"
+
+    expect(page).to have_css "h1", text: "Raw Hook #{raw_hook.id}"
+    expect(page).to have_current_path crud_raw_hook_path(raw_hook)
   end
 end

--- a/spec/system/crud/raw_hooks/admin_views_raw_hooks_spec.rb
+++ b/spec/system/crud/raw_hooks/admin_views_raw_hooks_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe "Admin views raw hooks" do
+  include_context "admin password matches"
+
+  scenario "from dashboard" do
+    visit "/dashboard"
+    click_on "Raw Hooks"
+    expect(page).to have_css "h1", text: "Raw Hooks"
+    expect(page).to have_current_path crud_raw_hooks_path
+  end
+
+  scenario "with no records" do
+    visit "/crud/raw_hooks"
+    expect(page.all("tbody tr").count).to eq 0
+  end
+
+  scenario "with a page of records" do
+    FactoryBot.create_list(:raw_hook, 3)
+    visit "/crud/raw_hooks"
+    expect(page.all("tbody tr").count).to eq 3
+    expect(page).to_not have_css "nav.pagination"
+  end
+
+  scenario "with two pages of records" do
+    FactoryBot.create_list(:raw_hook, 4)
+    visit "/crud/raw_hooks"
+    expect(page.all("tbody tr").count).to eq 3
+    expect(page).to have_css "nav.pagination"
+  end
+end

--- a/spec/system/crud/webhook_senders/admin_creates_webhook_sender_spec.rb
+++ b/spec/system/crud/webhook_senders/admin_creates_webhook_sender_spec.rb
@@ -1,0 +1,45 @@
+require "rails_helper"
+
+describe "Admin creates webhook sender" do
+  include_context "admin password matches"
+
+  scenario "from list page" do
+    visit "/crud/webhook_senders"
+    click_on "New Webhook Sender"
+    expect(page).to have_css "h1", text: "New Webhook Sender"
+    expect(page).to have_css "a", text: "Webhook Sender List"
+    expect(page).to have_current_path new_crud_webhook_sender_path
+  end
+
+  scenario "create with errors" do
+    visit "/crud/webhook_senders/new"
+    click_on "create"
+    expect(page).to have_css ".alert", text: "Name can't be blank and Parser can't be blank"
+    expect(page).to have_current_path new_crud_webhook_sender_path
+  end
+
+  scenario "create successfully" do
+    visit "/crud/webhook_senders/new"
+    fill_in "name", with: "Chatty Service"
+    fill_in "parser", with: "ChattyServiceParser"
+    click_on "create"
+
+    expect(page).to have_css ".notice", text: "Webhook Sender created"
+
+    webhook_sender = WebhookSender.last
+    expect(page).to have_current_path crud_webhook_sender_path(webhook_sender)
+
+    actual_values = page.all("tr").map do |table_row|
+      table_row.all("td").map(&:text)
+    end
+
+    expect(actual_values).to eq(
+      [
+        ["Name", "Chatty Service"],
+        ["Parser", "ChattyServiceParser"],
+        ["Created At", webhook_sender.created_at.to_fs],
+        ["Updated At", webhook_sender.updated_at.to_fs]
+      ]
+    )
+  end
+end

--- a/spec/system/crud/webhook_senders/admin_deletes_webhook_sender_spec.rb
+++ b/spec/system/crud/webhook_senders/admin_deletes_webhook_sender_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe "Admin deletes webhook sender" do
+  include_context "admin password matches"
+
+  let(:webhook_sender) { FactoryBot.create(:webhook_sender) }
+
+  scenario "cancels delete" do
+    visit "/crud/webhook_senders/#{webhook_sender.id}"
+
+    dismiss_confirm { click_on "Delete Webhook Sender" }
+
+    expect(WebhookSender.count).to eq 1
+    expect(page).to have_current_path crud_webhook_sender_path(webhook_sender)
+  end
+
+  scenario "confirms delete" do
+    visit "/crud/webhook_senders/#{webhook_sender.id}"
+
+    accept_confirm { click_on "Delete Webhook Sender" }
+
+    expect(page).to have_css ".notice", text: "Webhook Sender deleted"
+
+    expect(WebhookSender.count).to eq 0
+    expect(page).to have_current_path crud_webhook_senders_path
+  end
+end

--- a/spec/system/crud/webhook_senders/admin_edits_webhook_sender_spec.rb
+++ b/spec/system/crud/webhook_senders/admin_edits_webhook_sender_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe "Admin edits webhook sender" do
+  include_context "admin password matches"
+
+  scenario "from show page" do
+    webhook_sender = FactoryBot.create(:webhook_sender)
+    visit "/crud/webhook_senders/#{webhook_sender.id}"
+    click_on "Edit Webhook Sender"
+    expect(page).to have_css "h1", text: "Edit Webhook Sender #{webhook_sender.id}"
+    expect(page).to have_css "a", text: "Show Webhook Sender"
+    expect(page).to have_current_path edit_crud_webhook_sender_path(webhook_sender)
+  end
+
+  scenario "edit with errors" do
+    webhook_sender = FactoryBot.create(:webhook_sender)
+    visit "/crud/webhook_senders/#{webhook_sender.id}/edit"
+    fill_in "name", with: ""
+    click_on "update"
+    expect(page).to have_css ".alert", text: "Name can't be blank"
+  end
+
+  scenario "edit successfully" do
+    webhook_sender = FactoryBot.create(
+      :webhook_sender,
+      name: "Chatty Serbice"
+    )
+    visit "/crud/webhook_senders/#{webhook_sender.id}/edit"
+    fill_in "name", with: "Chatty Service"
+    click_on "update"
+
+    expect(page).to have_css ".notice", text: "Webhook Sender updated"
+    expect(page).to have_current_path crud_webhook_sender_path(webhook_sender)
+    expect(page).to have_css "td", text: "Chatty Service"
+  end
+end

--- a/spec/system/crud/webhook_senders/admin_views_webhook_sender_spec.rb
+++ b/spec/system/crud/webhook_senders/admin_views_webhook_sender_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+describe "Admin views webhook sender" do
+  include_context "admin password matches"
+
+  scenario "from list page" do
+    webhook_sender = FactoryBot.create(:webhook_sender)
+    visit "/crud/webhook_senders"
+    click_on webhook_sender.id.to_s
+    expect(page).to have_css "h1", text: "Webhook Sender #{webhook_sender.id}"
+    expect(page).to have_css "a", text: "Webhook Sender List"
+    expect(page).to have_current_path crud_webhook_sender_path(webhook_sender)
+  end
+
+  scenario "viewing a record" do
+    webhook_sender = FactoryBot.create(
+      :webhook_sender,
+      name: "Chatty Service",
+      parser: "ChattyServiceParser"
+    )
+
+    visit "/crud/webhook_senders/#{webhook_sender.id}"
+
+    actual_values = page.all("tr").map do |table_row|
+      table_row.all("td").map(&:text)
+    end
+
+    expect(actual_values).to eq(
+      [
+        ["Name", "Chatty Service"],
+        ["Parser", "ChattyServiceParser"],
+        ["Created At", webhook_sender.created_at.to_fs],
+        ["Updated At", webhook_sender.updated_at.to_fs]
+      ]
+    )
+  end
+
+  scenario "views random record" do
+    webhook_sender = FactoryBot.create(:webhook_sender)
+    expect(WebhookSender).to receive(:random).and_return(webhook_sender)
+
+    visit "/crud/webhook_senders"
+    click_on "Random Webhook Sender"
+
+    expect(page).to have_css "h1", text: "Webhook Sender #{webhook_sender.id}"
+    expect(page).to have_current_path crud_webhook_sender_path(webhook_sender)
+  end
+end

--- a/spec/system/crud/webhook_senders/admin_views_webhook_senders_spec.rb
+++ b/spec/system/crud/webhook_senders/admin_views_webhook_senders_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe "Admin views webhook senders" do
+  include_context "admin password matches"
+
+  scenario "from dashboard" do
+    visit "/dashboard"
+    click_on "Webhook Senders"
+    expect(page).to have_css "h1", text: "Webhook Senders"
+    expect(page).to have_current_path crud_webhook_senders_path
+  end
+
+  scenario "with no records" do
+    visit "/crud/webhook_senders"
+    expect(page.all("tbody tr").count).to eq 0
+  end
+
+  scenario "with a page of records" do
+    FactoryBot.create_list(:webhook_sender, 3)
+    visit "/crud/webhook_senders"
+    expect(page.all("tbody tr").count).to eq 3
+    expect(page).to_not have_css "nav.pagination"
+  end
+
+  scenario "with two pages of records" do
+    FactoryBot.create_list(:webhook_sender, 4)
+    visit "/crud/webhook_senders"
+    expect(page.all("tbody tr").count).to eq 3
+    expect(page).to have_css "nav.pagination"
+  end
+end


### PR DESCRIPTION
This PR adds two new sets of CRUD pages for webhook senders and the raw hook records they create. They are the parents of the hook records that are created in order to show something sensible on the Cybertail page. I considered making a hook section but it wasn't clear how or what that would get me so I bailed.