### PR TITLE
Add system test for cybertail

### DIFF
--- a/app/models/hook.rb
+++ b/app/models/hook.rb
@@ -7,6 +7,6 @@ class Hook < ApplicationRecord
   private
 
   def created
-    broadcast_prepend_later_to "hooks"
+    broadcast_prepend_later_to "hooks", template: "cybertail/_hook"
   end
 end

--- a/app/views/cybertail/_hook.html.haml
+++ b/app/views/cybertail/_hook.html.haml
@@ -1,0 +1,3 @@
+%li.flex.m-0.p-0.mb-4
+  = image_tag(hook.webhook_sender.logo_name, class: "w-8 m-0 h-8 mr-2")
+  %span.line-clamp-1= link_to hook.message, crud_raw_hook_path(hook.raw_hook)

--- a/app/views/cybertail/index.html.haml
+++ b/app/views/cybertail/index.html.haml
@@ -1,7 +1,3 @@
 %h1 Cybertail!
 = turbo_stream_from "hooks"
-%ul#hooks.bg-off-white.m-0.p-2
-  - hooks.each do |hook|
-    %li.flex.m-0.p-0.mb-4
-      = image_tag(hook.webhook_sender.logo_name, class: "w-8 m-0 h-8 mr-2")
-      %span.line-clamp-1= link_to hook.message, crud_raw_hook_path(hook.raw_hook)
+%ul#hooks.bg-off-white.m-0.p-2= render partial: "hook", collection: hooks

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -12,6 +12,7 @@ ActiveRecord::Migration.maintain_test_schema!
 
 RSpec.configure do |config|
   config.filter_rails_from_backtrace!
+  config.include ActiveJob::TestHelper
   config.include ActiveSupport::Testing::TimeHelpers
   config.infer_spec_type_from_file_location!
   config.use_transactional_fixtures = true

--- a/spec/system/cybertail/admin_views_cybertail_page_spec.rb
+++ b/spec/system/cybertail/admin_views_cybertail_page_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+describe "Admin views Cybertail page", js: true do
+  include_context "admin password matches"
+
+  scenario "something else" do
+    mock_parser = Class.new do
+      def self.check_and_maybe_parse(raw_hook)
+        raw_hook.create_hook(
+          message: raw_hook.body,
+          webhook_sender: WebhookSender.first
+        )
+      end
+    end
+    stub_const "MockParser", mock_parser
+
+    FactoryBot.create(:webhook_sender, parser: "MockParser")
+
+    perform_enqueued_jobs do
+      FactoryBot.create(:raw_hook, body: "first one")
+    end
+
+    visit "/cybertail"
+
+    expect(page).to have_css "li", text: "first one"
+    expect(page.all("li").count).to eq 1
+
+    perform_enqueued_jobs do
+      FactoryBot.create(:raw_hook, body: "second one")
+    end
+
+    expect(page).to have_css "li", text: "second one"
+    expect(page.all("li").count).to eq 2
+  end
+end


### PR DESCRIPTION
In my zeal to cleanup things over on https://github.com/jonallured/monolithium/pull/194 I accidentally broke the Cybertail page. I removed a partial for rendering an individual `Hook` record and that template was required in order for the Turbo broadcast to work when new webhooks are processed.

And I didn't know that I broke things initially because this page has no system tests - the PR was green. I think that I skipped doing any system tests because I wasn't totally sure how to do it. Turns out it wasn't too bad! I did have to learn about how to perform jobs using the `perform_enqueued_jobs` helper because I'm so used to doing this type of thing with `Sidekiq::Testing.inline`. It's really the same thing.

BUT then I also had to figure out how to make a `RawHook` record that would create and broadcast a `Hook` record. I did this by creating a mock parser that takes the body from the `RawHook` and sets that as the `message` on the `Hook`. I used `stub_const`, a recently learned trick that I really like.

Lastly I had to annotate the test with `js: true` and then that was all that it really took. I got to red because that partial I mentioned was missing. Once I got there then I could add it back and get to green. Pretty happy with how this turned out and now I have a new system test that ensures I can't break the Cybertail page in the same way again without knowing it!