### PR TITLE
Fully setup crud pages for post bin

### DIFF
--- a/app/controllers/crud/post_bin_requests_controller.rb
+++ b/app/controllers/crud/post_bin_requests_controller.rb
@@ -1,4 +1,42 @@
 class Crud::PostBinRequestsController < ApplicationController
   expose(:post_bin_request)
-  expose(:post_bin_requests) { PostBinRequest.all.order(created_at: :desc).limit(10) }
+  expose(:post_bin_requests) do
+    PostBinRequest.order(created_at: :desc).page(params[:page])
+  end
+
+  def show
+    redirect_to crud_post_bin_request_path(PostBinRequest.random) if params[:id] == "random"
+  end
+
+  def create
+    if post_bin_request.save
+      flash.notice = "Post Bin Request created"
+      redirect_to crud_post_bin_request_path(post_bin_request)
+    else
+      flash.alert = post_bin_request.errors.full_messages.to_sentence
+      redirect_to new_crud_post_bin_request_path
+    end
+  end
+
+  def update
+    if post_bin_request.update(post_bin_request_params)
+      flash.notice = "Post Bin Request updated"
+      redirect_to crud_post_bin_request_path(post_bin_request)
+    else
+      flash.alert = post_bin_request.errors.full_messages.to_sentence
+      redirect_to edit_crud_post_bin_request_path(post_bin_request)
+    end
+  end
+
+  def destroy
+    post_bin_request.destroy
+    flash.notice = "Post Bin Request deleted"
+    redirect_to crud_post_bin_requests_path
+  end
+
+  private
+
+  def post_bin_request_params
+    params.require(:post_bin_request).permit(:body, :headers, :params)
+  end
 end

--- a/app/controllers/post_bin_controller.rb
+++ b/app/controllers/post_bin_controller.rb
@@ -1,0 +1,3 @@
+class PostBinController < ApplicationController
+  expose(:post_bin_requests) { PostBinRequest.all.order(created_at: :desc).limit(10) }
+end

--- a/app/models/post_bin_request.rb
+++ b/app/models/post_bin_request.rb
@@ -6,6 +6,6 @@ class PostBinRequest < ApplicationRecord
   private
 
   def created
-    broadcast_prepend_later_to CHANNEL_NAME
+    broadcast_prepend_later_to CHANNEL_NAME, template: "post_bin/_post_bin_request"
   end
 end

--- a/app/models/post_bin_request.rb
+++ b/app/models/post_bin_request.rb
@@ -3,6 +3,13 @@ class PostBinRequest < ApplicationRecord
 
   after_create_commit :created
 
+  def table_attrs
+    [
+      ["Created At", created_at.to_fs],
+      ["Updated At", updated_at.to_fs]
+    ]
+  end
+
   private
 
   def created

--- a/app/views/crud/post_bin_requests/_form.html.haml
+++ b/app/views/crud/post_bin_requests/_form.html.haml
@@ -1,0 +1,5 @@
+= form_with model: [:crud, post_bin_request] do |form|
+  = form.text_area :body, placeholder: "body"
+  = form.text_area :headers, placeholder: "headers"
+  = form.text_area :params, placeholder: "params"
+  = form.button button_label

--- a/app/views/crud/post_bin_requests/edit.html.haml
+++ b/app/views/crud/post_bin_requests/edit.html.haml
@@ -1,0 +1,5 @@
+%h1 Edit Post Bin Request #{post_bin_request.id}
+
+%p= link_to "Show Post Bin Request", crud_post_bin_request_path(post_bin_request)
+
+= render "form", post_bin_request: post_bin_request, button_label: "update"

--- a/app/views/crud/post_bin_requests/index.html.haml
+++ b/app/views/crud/post_bin_requests/index.html.haml
@@ -1,0 +1,20 @@
+%h1 Post Bin Requests
+
+%p= link_to "New Post Bin Request", new_crud_post_bin_request_path
+
+%p= link_to "Random Post Bin Request", crud_post_bin_request_path("random")
+
+%table
+  %thead
+    %tr
+      %th ID
+      %th Body Snippet
+      %th.text-right Created At
+  %tbody
+    - post_bin_requests.each do |post_bin_request|
+      %tr
+        %td= link_to post_bin_request.id, crud_post_bin_request_path(post_bin_request)
+        %td= post_bin_request.body.first(100)
+        %td.text-right= post_bin_request.created_at.to_fs
+
+= paginate post_bin_requests

--- a/app/views/crud/post_bin_requests/index.html.haml
+++ b/app/views/crud/post_bin_requests/index.html.haml
@@ -1,4 +1,0 @@
-%h1 Post Bin Requests
-
-= turbo_stream_from(PostBinRequest::CHANNEL_NAME)
-%ul#post_bin_requests= render partial: "post_bin_requests/post_bin_request", collection: post_bin_requests

--- a/app/views/crud/post_bin_requests/new.html.haml
+++ b/app/views/crud/post_bin_requests/new.html.haml
@@ -1,0 +1,5 @@
+%h1 New Post Bin Request
+
+%p= link_to "Post Bin Request List", crud_post_bin_requests_path
+
+= render "form", post_bin_request: post_bin_request, button_label: "create"

--- a/app/views/crud/post_bin_requests/show.html.haml
+++ b/app/views/crud/post_bin_requests/show.html.haml
@@ -1,16 +1,24 @@
 %h1 Post Bin Request #{post_bin_request.id}
 
-%p Headers
+%p= link_to "Post Bin Request List", crud_post_bin_requests_path
 
-%pre.text-off-black.h-72
+%p= link_to "Edit Post Bin Request", edit_crud_post_bin_request_path(post_bin_request)
+
+%p= link_to "Delete Post Bin Request", crud_post_bin_request_path(post_bin_request), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }
+
+= render partial: "attrs_table", locals: { attrs: post_bin_request.table_attrs }
+
+%h2 Headers
+
+%pre.text-off-black
   %code= JSON.pretty_generate(post_bin_request.headers)
 
-%p Params
+%h2 Params
 
-%pre.text-off-black.h-72
+%pre.text-off-black
   %code= JSON.pretty_generate(post_bin_request.params)
 
-%p Body
+%h2 Body
 
-%pre.text-off-black.h-72
+%pre.text-off-black
   %code= post_bin_request.body

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -26,6 +26,7 @@
 %p= link_to "CSV Uploads", crud_csv_uploads_path
 %p= link_to "Financial Accounts", crud_financial_accounts_path
 %p= link_to "Gift Ideas", crud_gift_ideas_path
+%p= link_to "Post Bin Requests", crud_post_bin_requests_path
 %p= link_to "Projects", crud_projects_path
 %p= link_to "Raw Hooks", crud_raw_hooks_path
 %p= link_to "Sneakers", crud_sneakers_path

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -15,6 +15,7 @@
 %p= link_to "Cybertail", cybertail_path
 %p= link_to "Financial Report", financial_report_path(year: Time.now.year)
 %p= link_to "Fuzzies", fuzzies_path
+%p= link_to "Live Post Bin", post_bin_path
 %p= link_to "Model Counts", model_counts_path
 %p= link_to "Project List", project_list_path
 %p= link_to "Today", today_path
@@ -25,7 +26,6 @@
 %p= link_to "CSV Uploads", crud_csv_uploads_path
 %p= link_to "Financial Accounts", crud_financial_accounts_path
 %p= link_to "Gift Ideas", crud_gift_ideas_path
-%p= link_to "Post Bin", crud_post_bin_requests_path
 %p= link_to "Projects", crud_projects_path
 %p= link_to "Raw Hooks", crud_raw_hooks_path
 %p= link_to "Sneakers", crud_sneakers_path

--- a/app/views/post_bin/_post_bin_request.html.haml
+++ b/app/views/post_bin/_post_bin_request.html.haml
@@ -1,0 +1,1 @@
+%li.m-0.my-4.p-0.line-clamp-1 #{post_bin_request.id} #{link_to post_bin_request.body, crud_post_bin_request_path(post_bin_request)}

--- a/app/views/post_bin/index.html.haml
+++ b/app/views/post_bin/index.html.haml
@@ -1,0 +1,8 @@
+%h1 Live Post Bin
+%p To see somethign show up here make a request like so:
+%pre.text-off-black
+  %code
+    $ MLI_CLIENT_TOKEN=$(bundle exec rails runner "print Monolithium.config.client_token")
+    $ http https://app.jonallured.com/api/v1/post_bin X-MLI-CLIENT-TOKEN:$MLI_CLIENT_TOKEN foo=bar
+= turbo_stream_from(PostBinRequest::CHANNEL_NAME)
+%ul.m-0.p-0#post_bin_requests= render partial: "post_bin_request", collection: post_bin_requests

--- a/app/views/post_bin_requests/_post_bin_request.html.haml
+++ b/app/views/post_bin_requests/_post_bin_request.html.haml
@@ -1,1 +1,0 @@
-%li= link_to post_bin_request.id, admin_post_bin_request_path(post_bin_request)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   get "financial_reports/:year", to: "financial_reports#show", as: :financial_report
   get "fuzzies", to: "fuzzies#index", as: :fuzzies
   get "model_counts", to: "model_counts#index", as: :model_counts
+  get "post_bin", to: "post_bin#index"
   get "reading-list/:year", to: "reading_list#index", as: :reading_list
   get "sneakers", to: "sneakers#index", as: :sneakers
   get "today", to: "today#show", as: :today
@@ -40,7 +41,7 @@ Rails.application.routes.draw do
       resources :financial_statements
     end
     resources :gift_ideas
-    resources :post_bin_requests, only: %i[index show]
+    resources :post_bin_requests, only: :show
     resources :projects
     resources :raw_hooks
     resources :sneakers

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,7 +41,7 @@ Rails.application.routes.draw do
       resources :financial_statements
     end
     resources :gift_ideas
-    resources :post_bin_requests, only: :show
+    resources :post_bin_requests
     resources :projects
     resources :raw_hooks
     resources :sneakers

--- a/spec/system/crud/post_bin_requests/admin_creates_post_bin_request_spec.rb
+++ b/spec/system/crud/post_bin_requests/admin_creates_post_bin_request_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe "Admin creates post bin request" do
+  include_context "admin password matches"
+
+  scenario "from list page" do
+    visit "/crud/post_bin_requests"
+    click_on "New Post Bin Request"
+    expect(page).to have_css "h1", text: "New Post Bin Request"
+    expect(page).to have_css "a", text: "Post Bin Request List"
+    expect(page).to have_current_path new_crud_post_bin_request_path
+  end
+
+  scenario "create successfully" do
+    visit "/crud/post_bin_requests/new"
+    fill_in "body", with: "payload"
+    fill_in "headers", with: {"x-header-name" => "header-value"}.to_json
+    fill_in "params", with: {"param-name" => "param-value"}.to_json
+    click_on "create"
+
+    expect(page).to have_css ".notice", text: "Post Bin Request created"
+
+    post_bin_request = PostBinRequest.last
+    expect(page).to have_current_path crud_post_bin_request_path(post_bin_request)
+
+    actual_values = page.all("tr").map do |table_row|
+      table_row.all("td").map(&:text)
+    end
+
+    expect(actual_values).to eq(
+      [
+        ["Created At", post_bin_request.created_at.to_fs],
+        ["Updated At", post_bin_request.updated_at.to_fs]
+      ]
+    )
+
+    expect(page.all("h2").map(&:text)).to eq %w[Headers Params Body]
+    expect(page.all("pre code").map(&:text)).to eq(
+      [
+        JSON.pretty_generate(post_bin_request.headers),
+        JSON.pretty_generate(post_bin_request.params),
+        post_bin_request.body
+      ]
+    )
+  end
+end

--- a/spec/system/crud/post_bin_requests/admin_deletes_post_bin_request_spec.rb
+++ b/spec/system/crud/post_bin_requests/admin_deletes_post_bin_request_spec.rb
@@ -1,0 +1,27 @@
+require "rails_helper"
+
+describe "Admin deletes post bin request" do
+  include_context "admin password matches"
+
+  let(:post_bin_request) { FactoryBot.create(:post_bin_request) }
+
+  scenario "cancels delete" do
+    visit "/crud/post_bin_requests/#{post_bin_request.id}"
+
+    dismiss_confirm { click_on "Delete Post Bin Request" }
+
+    expect(PostBinRequest.count).to eq 1
+    expect(page).to have_current_path crud_post_bin_request_path(post_bin_request)
+  end
+
+  scenario "confirms delete" do
+    visit "/crud/post_bin_requests/#{post_bin_request.id}"
+
+    accept_confirm { click_on "Delete Post Bin Request" }
+
+    expect(page).to have_css ".notice", text: "Post Bin Request deleted"
+
+    expect(PostBinRequest.count).to eq 0
+    expect(page).to have_current_path crud_post_bin_requests_path
+  end
+end

--- a/spec/system/crud/post_bin_requests/admin_edits_post_bin_request_spec.rb
+++ b/spec/system/crud/post_bin_requests/admin_edits_post_bin_request_spec.rb
@@ -1,0 +1,28 @@
+require "rails_helper"
+
+describe "Admin edits post bin request" do
+  include_context "admin password matches"
+
+  scenario "from show page" do
+    post_bin_request = FactoryBot.create(:post_bin_request)
+    visit "/crud/post_bin_requests/#{post_bin_request.id}"
+    click_on "Edit Post Bin Request"
+    expect(page).to have_css "h1", text: "Edit Post Bin Request #{post_bin_request.id}"
+    expect(page).to have_css "a", text: "Show Post Bin Request"
+    expect(page).to have_current_path edit_crud_post_bin_request_path(post_bin_request)
+  end
+
+  scenario "edit successfully" do
+    post_bin_request = FactoryBot.create(
+      :post_bin_request,
+      body: "very lame bayload"
+    )
+    visit "/crud/post_bin_requests/#{post_bin_request.id}/edit"
+    fill_in "body", with: "very cool payload"
+    click_on "update"
+
+    expect(page).to have_css ".notice", text: "Post Bin Request updated"
+    expect(page).to have_current_path crud_post_bin_request_path(post_bin_request)
+    expect(page).to have_css "pre code", text: "very cool payload"
+  end
+end

--- a/spec/system/crud/post_bin_requests/admin_views_post_bin_request_spec.rb
+++ b/spec/system/crud/post_bin_requests/admin_views_post_bin_request_spec.rb
@@ -1,0 +1,56 @@
+require "rails_helper"
+
+describe "Admin views post bin request" do
+  include_context "admin password matches"
+
+  scenario "from list page" do
+    post_bin_request = FactoryBot.create(:post_bin_request)
+    visit "/crud/post_bin_requests"
+    click_on post_bin_request.id.to_s
+    expect(page).to have_css "h1", text: "Post Bin Request #{post_bin_request.id}"
+    expect(page).to have_css "a", text: "Post Bin Request List"
+    expect(page).to have_current_path crud_post_bin_request_path(post_bin_request)
+  end
+
+  scenario "viewing a record" do
+    post_bin_request = FactoryBot.create(
+      :post_bin_request,
+      body: "payload",
+      headers: {"x-header-name" => "header-value"}.to_json,
+      params: {"param-name" => "param-value"}.to_json
+    )
+
+    visit "/crud/post_bin_requests/#{post_bin_request.id}"
+
+    actual_values = page.all("tr").map do |table_row|
+      table_row.all("td").map(&:text)
+    end
+
+    expect(actual_values).to eq(
+      [
+        ["Created At", post_bin_request.created_at.to_fs],
+        ["Updated At", post_bin_request.updated_at.to_fs]
+      ]
+    )
+
+    expect(page.all("h2").map(&:text)).to eq %w[Headers Params Body]
+    expect(page.all("pre code").map(&:text)).to eq(
+      [
+        JSON.pretty_generate(post_bin_request.headers),
+        JSON.pretty_generate(post_bin_request.params),
+        post_bin_request.body
+      ]
+    )
+  end
+
+  scenario "views random record" do
+    post_bin_request = FactoryBot.create(:post_bin_request)
+    expect(PostBinRequest).to receive(:random).and_return(post_bin_request)
+
+    visit "/crud/post_bin_requests"
+    click_on "Random Post Bin Request"
+
+    expect(page).to have_css "h1", text: "Post Bin Request #{post_bin_request.id}"
+    expect(page).to have_current_path crud_post_bin_request_path(post_bin_request)
+  end
+end

--- a/spec/system/crud/post_bin_requests/admin_views_post_bin_requests_spec.rb
+++ b/spec/system/crud/post_bin_requests/admin_views_post_bin_requests_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe "Admin views post bin requests" do
+  include_context "admin password matches"
+
+  scenario "from dashboard" do
+    visit "/dashboard"
+    click_on "Post Bin Requests"
+    expect(page).to have_css "h1", text: "Post Bin Requests"
+    expect(page).to have_current_path crud_post_bin_requests_path
+  end
+
+  scenario "with no records" do
+    visit "/crud/post_bin_requests"
+    expect(page.all("tbody tr").count).to eq 0
+  end
+
+  scenario "with a page of records" do
+    FactoryBot.create_list(:post_bin_request, 3)
+    visit "/crud/post_bin_requests"
+    expect(page.all("tbody tr").count).to eq 3
+    expect(page).to_not have_css "nav.pagination"
+  end
+
+  scenario "with two pages of records" do
+    FactoryBot.create_list(:post_bin_request, 4)
+    visit "/crud/post_bin_requests"
+    expect(page.all("tbody tr").count).to eq 3
+    expect(page).to have_css "nav.pagination"
+  end
+end

--- a/spec/system/post_bin/admin_views_post_bin_spec.rb
+++ b/spec/system/post_bin/admin_views_post_bin_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+describe "Admin views post bin", js: true do
+  include_context "admin password matches"
+
+  scenario "with an initial post bin request and then another is created" do
+    FactoryBot.create(:post_bin_request, body: "first one")
+
+    visit "/post_bin"
+
+    expect(page).to have_css "li a", text: "first one"
+    expect(page.all("li").count).to eq 1
+
+    perform_enqueued_jobs do
+      FactoryBot.create(:post_bin_request, body: "second one")
+    end
+
+    expect(page).to have_css "li a", text: "second one"
+    expect(page.all("li").count).to eq 2
+  end
+end


### PR DESCRIPTION
When I created the Post Bin pages on https://github.com/jonallured/monolithium/pull/133 it was WAY before I had CRUD pages like I do now. I did some weirdo thing where the post bin page and the admin pages were sorta mixed together. This PR teases this all apart and lands two things:

1. the live post bin page
2. my standard CRUD pages for `PostBinRequest` records

The live page links to the show page for the record and things make a lot more sense now. It's also even more clear how much Post Bin and Cybertail have in common. 😬 