### PR TITLE
Extract base parser class

### DIFF
--- a/app/parsers/base_parser.rb
+++ b/app/parsers/base_parser.rb
@@ -1,0 +1,17 @@
+class BaseParser
+  def self.check_and_maybe_parse(raw_hook)
+    parse(raw_hook) if valid_for?(raw_hook) && can_parse?(raw_hook)
+  end
+
+  def self.can_parse?(raw_hook)
+    raise StandardError
+  end
+
+  def self.valid_for?(raw_hook)
+    raise StandardError
+  end
+
+  def self.parse(raw_hook)
+    raise StandardError
+  end
+end

--- a/app/parsers/circleci_parser.rb
+++ b/app/parsers/circleci_parser.rb
@@ -1,14 +1,10 @@
-class CircleciParser
+class CircleciParser < BaseParser
   EVENT_TYPE_KEY = "HTTP_CIRCLECI_EVENT_TYPE"
   SIGNATURE_HEADER_KEY = "HTTP_CIRCLECI_SIGNATURE"
   USER_AGENT_KEY = "HTTP_USER_AGENT"
 
   KNOWN_EVENT_TYPES = %w[job-completed workflow-completed]
   KNOWN_USER_AGENT = "CircleCI-Webhook/1.0"
-
-  def self.check_and_maybe_parse(raw_hook)
-    parse(raw_hook) if valid_for?(raw_hook) && can_parse?(raw_hook)
-  end
 
   def self.valid_for?(raw_hook)
     signature = raw_hook.headers[SIGNATURE_HEADER_KEY] || ""

--- a/app/parsers/github_parser.rb
+++ b/app/parsers/github_parser.rb
@@ -1,14 +1,10 @@
-class GithubParser
+class GithubParser < BaseParser
   EVENT_TYPE_KEY = "HTTP_X_GITHUB_EVENT"
   SIGNATURE_HEADER_KEY = "HTTP_X_HUB_SIGNATURE_256"
   USER_AGENT_KEY = "HTTP_USER_AGENT"
 
   KNOWN_EVENT_TYPES = %w[pull_request]
   KNOWN_USER_AGENT = "GitHub-Hookshot"
-
-  def self.check_and_maybe_parse(raw_hook)
-    parse(raw_hook) if valid_for?(raw_hook) && can_parse?(raw_hook)
-  end
 
   def self.valid_for?(raw_hook)
     signature = raw_hook.headers[SIGNATURE_HEADER_KEY] || ""

--- a/app/parsers/heroku_parser.rb
+++ b/app/parsers/heroku_parser.rb
@@ -1,10 +1,6 @@
-class HerokuParser
+class HerokuParser < BaseParser
   HMAC_HEADER_KEY = "HTTP_HEROKU_WEBHOOK_HMAC_SHA256"
   KNOWN_VERSION = "application/vnd.heroku+json; version=3"
-
-  def self.check_and_maybe_parse(raw_hook)
-    parse(raw_hook) if valid_for?(raw_hook) && can_parse?(raw_hook)
-  end
 
   def self.valid_for?(raw_hook)
     actual_hmac = raw_hook.headers[HMAC_HEADER_KEY]

--- a/app/parsers/rubygems_parser.rb
+++ b/app/parsers/rubygems_parser.rb
@@ -1,4 +1,4 @@
-class RubygemsParser
+class RubygemsParser < BaseParser
   SIGNATURE_HEADER_KEY = "HTTP_AUTHORIZATION"
 
   def self.valid_for?(raw_hook)


### PR DESCRIPTION
Over on #201 I failed to do something: extract a base class for the methods these classes share. I meant to but then time passed and I forgot. So this PR extracts that class and uses it in the four webhook parser classes.

This matters because without this base class and the shared logic of the `self.check_and_maybe_parse` method then I can't properly parse RubyGems.org webhooks.