### PR TITLE
Load marketing collections more safely

### DIFF
--- a/app/models/marketing_collections.rb
+++ b/app/models/marketing_collections.rb
@@ -5,7 +5,6 @@ class MarketingCollections
     contemporary-now
     finds-under-1000-dollars
     iconic-prints
-    street-art-highlights
     top-auction-lots
     trending-this-week
     trove-editors-picks
@@ -14,6 +13,8 @@ class MarketingCollections
   def self.load_artworks
     SLUGS.each do |slug|
       data = MetaphysicsApi.marketing_collection(slug)
+      next if data.marketing_collection.nil?
+
       nodes = data.marketing_collection.artworks_connection.edges.map(&:node)
       new_nodes = nodes.reject { |node| Artwork.exists?(gravity_id: node.gravity_id) }
       new_nodes.each do |node|


### PR DESCRIPTION
Hot on the heels of #206 where I realized I had a recurring exception about a naming goof, this PR fixes a problem where a certain query was failing with an invalid slug. Rather than moving onto the next slug it was raising an exception. This way we actually just recover and move on. But while I was at it I also removed the invalid slug too.