### PR TITLE
Improve live post bin links

### DIFF
--- a/app/views/post_bin/_post_bin_request.html.haml
+++ b/app/views/post_bin/_post_bin_request.html.haml
@@ -1,1 +1,2 @@
-%li.m-0.my-4.p-0.line-clamp-1 #{post_bin_request.id} #{link_to post_bin_request.body, crud_post_bin_request_path(post_bin_request)}
+%li.m-0.my-4.p-0.line-clamp-1
+  = link_to "#{[post_bin_request.id, post_bin_request.body].join(" ")}", crud_post_bin_request_path(post_bin_request)

--- a/spec/system/post_bin/admin_views_post_bin_spec.rb
+++ b/spec/system/post_bin/admin_views_post_bin_spec.rb
@@ -4,18 +4,18 @@ describe "Admin views post bin", js: true do
   include_context "admin password matches"
 
   scenario "with an initial post bin request and then another is created" do
-    FactoryBot.create(:post_bin_request, body: "first one")
+    first_one = FactoryBot.create(:post_bin_request, body: "first one")
 
     visit "/post_bin"
 
-    expect(page).to have_css "li a", text: "first one"
+    expect(page).to have_css "li a", text: "#{first_one.id} first one"
     expect(page.all("li").count).to eq 1
 
     perform_enqueued_jobs do
-      FactoryBot.create(:post_bin_request, body: "second one")
-    end
+      second_one = FactoryBot.create(:post_bin_request, body: "")
 
-    expect(page).to have_css "li a", text: "second one"
-    expect(page.all("li").count).to eq 2
+      expect(page).to have_css "li a", text: second_one.id
+      expect(page.all("li").count).to eq 2
+    end
   end
 end


### PR DESCRIPTION
I sorta forgot that some post bin requests will not have a body so that wasn't the best choice for this link. If I include the ID in the link then that's good enough.