### PR TITLE
Produce daily packet every day

### DIFF
--- a/app/jobs/one_day_job.rb
+++ b/app/jobs/one_day_job.rb
@@ -1,5 +1,6 @@
 class OneDayJob < ApplicationJob
   def perform
     RawHook.destroy_all
+    DailyPacket.produce_for(Date.today)
   end
 end

--- a/app/models/daily_packet.rb
+++ b/app/models/daily_packet.rb
@@ -1,0 +1,7 @@
+class DailyPacket
+  def self.produce_for(date)
+    file_path = "daily-packets/#{date.strftime("%Y-%m-%d")}.pdf"
+    packet = DailyPacketView.new(date)
+    S3Api.write(file_path, packet.pdf_data)
+  end
+end

--- a/app/models/daily_packet_view.rb
+++ b/app/models/daily_packet_view.rb
@@ -8,6 +8,10 @@ class DailyPacketView
     build
   end
 
+  def pdf_data
+    document.render
+  end
+
   private
 
   def build

--- a/spec/models/daily_packet_spec.rb
+++ b/spec/models/daily_packet_spec.rb
@@ -1,0 +1,18 @@
+require "rails_helper"
+
+describe DailyPacket do
+  describe ".produce_for" do
+    it "renders and writes the pdf data to s3" do
+      mock_view = double(:mock_view, pdf_data: "PDF GOES HERE")
+      expect(DailyPacketView).to receive(:new).and_return(mock_view)
+
+      expect(S3Api).to receive(:write).with(
+        "daily-packets/2001-02-03.pdf",
+        "PDF GOES HERE"
+      )
+
+      date = Date.parse("2001-02-03")
+      DailyPacket.produce_for(date)
+    end
+  end
+end

--- a/spec/models/daily_packet_view_spec.rb
+++ b/spec/models/daily_packet_view_spec.rb
@@ -4,8 +4,7 @@ describe DailyPacketView do
   it "renders the document" do
     built_on = Date.new(2007, 7, 7)
     view = DailyPacketView.new(built_on)
-    pdf_data = view.document.render
-    inspector = PDF::Inspector::Text.analyze(pdf_data)
+    inspector = PDF::Inspector::Text.analyze(view.pdf_data)
     expect(inspector.strings).to eq([
       "Daily Packet",
       "07/07/2007, week 27",


### PR DESCRIPTION
This PR wires up the `DailyPacketView` with the `OneDayJob` via a new class/method called `DailyPacket.produce_for`. I added this so that I could separate the drawing from the creation/storage of the pdf. I think this is all it would take for these things to be made every day automatically.