### PR TITLE
Delete all webhook data with single SQL statements

### DIFF
--- a/app/jobs/one_day_job.rb
+++ b/app/jobs/one_day_job.rb
@@ -1,6 +1,7 @@
 class OneDayJob < ApplicationJob
   def perform
-    RawHook.destroy_all
+    Hook.delete_all
+    RawHook.delete_all
     DailyPacket.produce_for(Date.today)
   end
 end


### PR DESCRIPTION
I added the Daily Packet to this once-a-day job and nothing happened. So then I manually watched the job and noticed that the worker was out of memory. That lead to the realization that I had been lazy when deleting all the webhook data - I used the `destroy_all` method rather than `delete_all`. Using `destroy` methods causes Rails lifecycle hooks to fire and is super slow. Using `delete` methods skips all that and directly calls down to SQL to delete the data.

So given all that - I decided to just simply use the `delete` methods on the `Hook` and `RawHook` models to empty these tables once a day. That should be much easier!