### PR TITLE
Add top three to daily packet

### DIFF
--- a/app/models/daily_packet_view.rb
+++ b/app/models/daily_packet_view.rb
@@ -16,9 +16,11 @@ class DailyPacketView
 
   def build
     stroke_color "000000"
-
     define_grid(columns: 6, rows: 12, gutter: 12)
+    draw_front_page
+  end
 
+  def draw_front_page
     grid([0, 0], [0, 2]).bounding_box do
       text "Daily Packet", style: :bold_italic, size: 42, valign: :center
     end

--- a/app/models/daily_packet_view.rb
+++ b/app/models/daily_packet_view.rb
@@ -18,6 +18,8 @@ class DailyPacketView
     stroke_color "000000"
     define_grid(columns: 6, rows: 12, gutter: 12)
     draw_front_page
+    start_new_page
+    draw_top_three_page
   end
 
   def draw_front_page
@@ -51,6 +53,42 @@ class DailyPacketView
         text "Reading Pace", style: :bold
         text "#{@reading_list.pace} pages/day"
       end
+    end
+  end
+
+  def draw_top_three_page
+    text "TOP THREE", align: :center, size: 40
+
+    stroke do
+      horizontal_rule
+    end
+
+    move_down 30
+
+    text "Personal", size: 30
+
+    move_down 10
+
+    font_size(20) do
+      text "1. #{"_" * 40}"
+      move_down 10
+      text "2. #{"_" * 40}"
+      move_down 10
+      text "3. #{"_" * 40}"
+    end
+
+    move_down 30
+
+    text "Work", size: 30
+
+    move_down 10
+
+    font_size(20) do
+      text "1. #{"_" * 40}"
+      move_down 10
+      text "2. #{"_" * 40}"
+      move_down 10
+      text "3. #{"_" * 40}"
     end
   end
 end

--- a/spec/models/daily_packet_view_spec.rb
+++ b/spec/models/daily_packet_view_spec.rb
@@ -4,13 +4,30 @@ describe DailyPacketView do
   it "renders the document" do
     built_on = Date.new(2007, 7, 7)
     view = DailyPacketView.new(built_on)
-    inspector = PDF::Inspector::Text.analyze(view.pdf_data)
-    expect(inspector.strings).to eq([
+    inspector = PDF::Inspector::Page.analyze(view.pdf_data)
+
+    expect(inspector.pages.size).to eq 2
+
+    page_one_strings, page_two_strings = inspector.pages.map { |page| page[:strings] }
+
+    expect(page_one_strings).to eq([
       "Daily Packet",
       "07/07/2007, week 27",
       "Random Warm Fuzzy",
       "Reading Pace",
       "0.0 pages/day"
+    ])
+
+    expect(page_two_strings).to eq([
+      "TOP THREE",
+      "Personal",
+      "1. #{"_" * 40}",
+      "2. #{"_" * 40}",
+      "3. #{"_" * 40}",
+      "Work",
+      "1. #{"_" * 40}",
+      "2. #{"_" * 40}",
+      "3. #{"_" * 40}"
     ])
   end
 end


### PR DESCRIPTION
This PR adds a second page to the Daily Packet - this one for writing out my Top Three for the day. I adjusted things slightly so that I could keep the test assertions tight by using the page inspector. I also extracted some methods for drawing each page so that the build method could be an "overview" type of method.