### PR TITLE
More dynamic lists for daily packet

### DIFF
--- a/app/models/daily_packet.rb
+++ b/app/models/daily_packet.rb
@@ -2,6 +2,7 @@ class DailyPacket < ApplicationRecord
   belongs_to :warm_fuzzy
 
   has_object :pdf_view
+  delegate :pdf_data, to: :pdf_view
 
   has_object :producer
   delegate :save_to_disk, :save_to_s3, to: :producer

--- a/app/models/daily_packet.rb
+++ b/app/models/daily_packet.rb
@@ -33,25 +33,34 @@ class DailyPacket < ApplicationRecord
   end
 
   def chore_list
-    built_on_weekend = built_on.saturday? || built_on.sunday?
-    built_on_summertime = (4..10).cover?(built_on.month)
-
     chores = []
     chores << "unload dishwasher"
-    chores << "collect laundry" if built_on_weekend
+    chores << "collect laundry" if built_on_weekend?
     chores << "defrost meat"
 
-    if built_on_weekend && built_on_summertime
+    if built_on_weekend? && built_during_summer?
       chores << "poop patrol"
       chores << "mow front"
       chores << "mow back"
       chores << "mow way back"
     end
 
-    chores << "put out garbage cans" if built_on.monday?
+    chores << "put out garbage cans" if built_on_monday?
     chores << "wipe off kitchen table"
     chores << "run dishwasher"
 
     chores
+  end
+
+  def built_on_monday?
+    built_on.monday?
+  end
+
+  def built_on_weekend?
+    built_on.saturday? || built_on.sunday?
+  end
+
+  def built_during_summer?
+    (4..10).cover?(built_on.month)
   end
 end

--- a/app/models/daily_packet.rb
+++ b/app/models/daily_packet.rb
@@ -31,4 +31,27 @@ class DailyPacket < ApplicationRecord
   def reading_list_phrase
     "#{reading_list_pace} pages/day"
   end
+
+  def chore_list
+    built_on_weekend = built_on.saturday? || built_on.sunday?
+    built_on_summertime = (4..10).cover?(built_on.month)
+
+    chores = []
+    chores << "unload dishwasher"
+    chores << "collect laundry" if built_on_weekend
+    chores << "defrost meat"
+
+    if built_on_weekend && built_on_summertime
+      chores << "poop patrol"
+      chores << "mow front"
+      chores << "mow back"
+      chores << "mow way back"
+    end
+
+    chores << "put out garbage cans" if built_on.monday?
+    chores << "wipe off kitchen table"
+    chores << "run dishwasher"
+
+    chores
+  end
 end

--- a/app/models/daily_packet/pdf_view.rb
+++ b/app/models/daily_packet/pdf_view.rb
@@ -100,22 +100,10 @@ class DailyPacket::PdfView < ActiveRecord::AssociatedObject
 
     move_down 30
 
-    built_on_weekend = daily_packet.built_on.saturday? || daily_packet.built_on.sunday?
-    built_on_summertime = (4..10).cover?(daily_packet.built_on.month)
-
     font_size(20) do
-      text "unload dishwasher"
-      text "collect laundry" if daily_packet.built_on.saturday? || daily_packet.built_on.sunday?
-      text "defrost meat"
-      if built_on_weekend && built_on_summertime
-        text "poop patrol"
-        text "mow front"
-        text "mow back"
-        text "mow way back"
+      daily_packet.chore_list.each do |chore|
+        text chore
       end
-      text "put out garbage cans" if daily_packet.built_on.monday?
-      text "wipe off kitchen table"
-      text "run dishwasher"
     end
   end
 end

--- a/app/models/daily_packet/pdf_view.rb
+++ b/app/models/daily_packet/pdf_view.rb
@@ -78,16 +78,18 @@ class DailyPacket::PdfView < ActiveRecord::AssociatedObject
 
     move_down 30
 
-    text "Work", size: 30
+    unless daily_packet.built_on_weekend?
+      text "Work", size: 30
 
-    move_down 10
+      move_down 10
 
-    font_size(20) do
-      text "1. #{"_" * 40}"
-      move_down 10
-      text "2. #{"_" * 40}"
-      move_down 10
-      text "3. #{"_" * 40}"
+      font_size(20) do
+        text "1. #{"_" * 40}"
+        move_down 10
+        text "2. #{"_" * 40}"
+        move_down 10
+        text "3. #{"_" * 40}"
+      end
     end
   end
 

--- a/app/models/daily_packet/pdf_view.rb
+++ b/app/models/daily_packet/pdf_view.rb
@@ -102,7 +102,7 @@ class DailyPacket::PdfView < ActiveRecord::AssociatedObject
 
     font_size(20) do
       text "unload dishwasher"
-      text "collect laundry"
+      text "collect laundry" if daily_packet.built_on.saturday? || daily_packet.built_on.sunday?
       text "defrost meat"
       text "poop patrol"
       text "mow front"

--- a/app/models/daily_packet/pdf_view.rb
+++ b/app/models/daily_packet/pdf_view.rb
@@ -108,7 +108,7 @@ class DailyPacket::PdfView < ActiveRecord::AssociatedObject
       text "mow front"
       text "mow back"
       text "mow way back"
-      text "put out garbage cans"
+      text "put out garbage cans" if daily_packet.built_on.monday?
       text "wipe off kitchen table"
       text "run dishwasher"
     end

--- a/app/models/daily_packet/pdf_view.rb
+++ b/app/models/daily_packet/pdf_view.rb
@@ -100,14 +100,19 @@ class DailyPacket::PdfView < ActiveRecord::AssociatedObject
 
     move_down 30
 
+    built_on_weekend = daily_packet.built_on.saturday? || daily_packet.built_on.sunday?
+    built_on_summertime = (4..10).cover?(daily_packet.built_on.month)
+
     font_size(20) do
       text "unload dishwasher"
       text "collect laundry" if daily_packet.built_on.saturday? || daily_packet.built_on.sunday?
       text "defrost meat"
-      text "poop patrol"
-      text "mow front"
-      text "mow back"
-      text "mow way back"
+      if built_on_weekend && built_on_summertime
+        text "poop patrol"
+        text "mow front"
+        text "mow back"
+        text "mow way back"
+      end
       text "put out garbage cans" if daily_packet.built_on.monday?
       text "wipe off kitchen table"
       text "run dishwasher"

--- a/app/models/daily_packet/producer.rb
+++ b/app/models/daily_packet/producer.rb
@@ -19,7 +19,7 @@ class DailyPacket::Producer < ActiveRecord::AssociatedObject
   def save_to_s3
     timestamp = daily_packet.built_on.strftime("%Y-%m-%d")
     s3_key = "daily-packets/#{timestamp}.pdf"
-    pdf_data = daily_packet.pdf_view.pdf_data
+    pdf_data = daily_packet.pdf_data
     S3Api.write(s3_key, pdf_data)
   end
 end

--- a/spec/models/daily_packet/pdf_view_spec.rb
+++ b/spec/models/daily_packet/pdf_view_spec.rb
@@ -63,6 +63,18 @@ describe DailyPacket::PdfView do
     end
   end
 
+  context "on a Saturday" do
+    let(:built_on) { Date.parse("2024-11-09") }
+
+    it "does not render the work top three section" do
+      inspector = PDF::Inspector::Page.analyze(daily_packet.pdf_data)
+
+      _, page_two_strings, _ = inspector.pages.map { |page| page[:strings] }
+
+      expect(page_two_strings).to_not include "Work"
+    end
+  end
+
   context "on a Saturday in the fall" do
     let(:built_on) { Date.parse("2024-11-09") }
 

--- a/spec/models/daily_packet/pdf_view_spec.rb
+++ b/spec/models/daily_packet/pdf_view_spec.rb
@@ -45,10 +45,6 @@ describe DailyPacket::PdfView do
         "Chore List",
         "unload dishwasher",
         "defrost meat",
-        "poop patrol",
-        "mow front",
-        "mow back",
-        "mow way back",
         "wipe off kitchen table",
         "run dishwasher"
       ])
@@ -67,15 +63,39 @@ describe DailyPacket::PdfView do
     end
   end
 
-  context "on a Saturday" do
+  context "on a Saturday in the fall" do
     let(:built_on) { Date.parse("2024-11-09") }
 
-    it "renders the Saturday-specific chore" do
+    it "renders the Weekend-specific chore but not the summertime ones" do
       inspector = PDF::Inspector::Page.analyze(daily_packet.pdf_data)
 
       _, _, page_three_strings = inspector.pages.map { |page| page[:strings] }
 
       expect(page_three_strings).to include "collect laundry"
+
+      expect(page_three_strings).to_not include(
+        "poop patrol",
+        "mow front",
+        "mow back",
+        "mow way back"
+      )
+    end
+  end
+
+  context "on a Saturday in the summer" do
+    let(:built_on) { Date.parse("2024-07-13") }
+
+    it "renders the summertime Weekend-specific chores" do
+      inspector = PDF::Inspector::Page.analyze(daily_packet.pdf_data)
+
+      _, _, page_three_strings = inspector.pages.map { |page| page[:strings] }
+
+      expect(page_three_strings).to include(
+        "poop patrol",
+        "mow front",
+        "mow back",
+        "mow way back"
+      )
     end
   end
 end

--- a/spec/models/daily_packet/pdf_view_spec.rb
+++ b/spec/models/daily_packet/pdf_view_spec.rb
@@ -44,7 +44,6 @@ describe DailyPacket::PdfView do
       expect(page_three_strings).to eq([
         "Chore List",
         "unload dishwasher",
-        "collect laundry",
         "defrost meat",
         "poop patrol",
         "mow front",
@@ -65,6 +64,18 @@ describe DailyPacket::PdfView do
       _, _, page_three_strings = inspector.pages.map { |page| page[:strings] }
 
       expect(page_three_strings).to include "put out garbage cans"
+    end
+  end
+
+  context "on a Saturday" do
+    let(:built_on) { Date.parse("2024-11-09") }
+
+    it "renders the Saturday-specific chore" do
+      inspector = PDF::Inspector::Page.analyze(daily_packet.pdf_data)
+
+      _, _, page_three_strings = inspector.pages.map { |page| page[:strings] }
+
+      expect(page_three_strings).to include "collect laundry"
     end
   end
 end

--- a/spec/models/daily_packet/pdf_view_spec.rb
+++ b/spec/models/daily_packet/pdf_view_spec.rb
@@ -1,55 +1,70 @@
 require "rails_helper"
 
 describe DailyPacket::PdfView do
-  it "renders the document" do
-    warm_fuzzy = FactoryBot.create(:warm_fuzzy, received_at: Time.at(0))
-    daily_packet = FactoryBot.create(:daily_packet, warm_fuzzy: warm_fuzzy)
-    view = DailyPacket::PdfView.new(daily_packet)
-    inspector = PDF::Inspector::Page.analyze(view.pdf_data)
+  let(:warm_fuzzy) { FactoryBot.create(:warm_fuzzy, received_at: Time.at(0)) }
+  let(:daily_packet) { FactoryBot.create(:daily_packet, built_on: built_on, warm_fuzzy: warm_fuzzy) }
 
-    expect(inspector.pages.size).to eq 3
+  context "on a Tuesday" do
+    let(:built_on) { Date.parse("2024-11-05") }
 
-    page_one_strings, page_two_strings, page_three_strings = inspector.pages.map { |page| page[:strings] }
+    it "renders the document" do
+      inspector = PDF::Inspector::Page.analyze(daily_packet.pdf_data)
 
-    expect(page_one_strings).to eq([
-      "Daily Packet ##{daily_packet.id}",
-      "07/07/2007",
-      "week 27",
-      "Random Warm Fuzzy",
-      "Alright Haircut",
-      "Your haircut is adequate.",
-      "- Wife, 01/01/1970",
-      "Reading Pace",
-      "7.7 pages/day",
-      "Feedbin Stats",
-      "unread: 9",
-      "oldest: 14 days ago"
-    ])
+      expect(inspector.pages.size).to eq 3
 
-    expect(page_two_strings).to eq([
-      "Top Three",
-      "Personal",
-      "1. #{"_" * 40}",
-      "2. #{"_" * 40}",
-      "3. #{"_" * 40}",
-      "Work",
-      "1. #{"_" * 40}",
-      "2. #{"_" * 40}",
-      "3. #{"_" * 40}"
-    ])
+      page_one_strings, page_two_strings, page_three_strings = inspector.pages.map { |page| page[:strings] }
 
-    expect(page_three_strings).to eq([
-      "Chore List",
-      "unload dishwasher",
-      "collect laundry",
-      "defrost meat",
-      "poop patrol",
-      "mow front",
-      "mow back",
-      "mow way back",
-      "put out garbage cans",
-      "wipe off kitchen table",
-      "run dishwasher"
-    ])
+      expect(page_one_strings).to eq([
+        "Daily Packet ##{daily_packet.id}",
+        "11/05/2024",
+        "week 45",
+        "Random Warm Fuzzy",
+        "Alright Haircut",
+        "Your haircut is adequate.",
+        "- Wife, 01/01/1970",
+        "Reading Pace",
+        "7.7 pages/day",
+        "Feedbin Stats",
+        "unread: 9",
+        "oldest: 14 days ago"
+      ])
+
+      expect(page_two_strings).to eq([
+        "Top Three",
+        "Personal",
+        "1. #{"_" * 40}",
+        "2. #{"_" * 40}",
+        "3. #{"_" * 40}",
+        "Work",
+        "1. #{"_" * 40}",
+        "2. #{"_" * 40}",
+        "3. #{"_" * 40}"
+      ])
+
+      expect(page_three_strings).to eq([
+        "Chore List",
+        "unload dishwasher",
+        "collect laundry",
+        "defrost meat",
+        "poop patrol",
+        "mow front",
+        "mow back",
+        "mow way back",
+        "wipe off kitchen table",
+        "run dishwasher"
+      ])
+    end
+  end
+
+  context "on a Monday" do
+    let(:built_on) { Date.parse("2024-11-04") }
+
+    it "renders the Monday-specific chore" do
+      inspector = PDF::Inspector::Page.analyze(daily_packet.pdf_data)
+
+      _, _, page_three_strings = inspector.pages.map { |page| page[:strings] }
+
+      expect(page_three_strings).to include "put out garbage cans"
+    end
   end
 end


### PR DESCRIPTION
This PR introduces more dynamic logic to the drawing of lists, especially for the Chore List page. I added methods to the `DailyPacket` so that I know when it is being drawn and show/hide various things depending on the date/season.

I also snuck in suppressing the work section on the top three page when it's the weekend.