### PR TITLE
Fix Lineup creation

### DIFF
--- a/app/jobs/create_lineup_job.rb
+++ b/app/jobs/create_lineup_job.rb
@@ -1,5 +1,7 @@
 class CreateLineupJob < ApplicationJob
   def perform
-    Lineup.create_next
+    while Lineup.current.nil?
+      Lineup.create_next
+    end
   end
 end

--- a/spec/jobs/create_lineup_job_spec.rb
+++ b/spec/jobs/create_lineup_job_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+describe CreateLineupJob do
+  context "when there is a Lineup from yesterday" do
+    let(:current_on) { Date.yesterday }
+
+    it "creates a Lineup for today" do
+      FactoryBot.create(:lineup, current_on: current_on)
+      expect(Lineup.current).to be_nil
+      expect do
+        CreateLineupJob.new.perform
+      end.to change(Lineup, :count).from(1).to(2)
+      expect(Lineup.current).to_not be_nil
+    end
+  end
+
+  context "when there is a gap in Lineup records" do
+    let(:current_on) { Date.today - 7.days }
+
+    it "creates enough Lineup records to catch up" do
+      FactoryBot.create(:lineup, current_on: current_on)
+      expect(Lineup.current).to be_nil
+      expect do
+        CreateLineupJob.new.perform
+      end.to change(Lineup, :count).from(1).to(8)
+      expect(Lineup.current).to_not be_nil
+    end
+  end
+end


### PR DESCRIPTION
When Lineup records are way behind then the daily job of creating the next one is insufficient to catch up. What this PR does is add a loop that will create enough Lineup records to ensure that a current one is created.