### PR TITLE
Add edition number to daily packets

### DIFF
--- a/app/models/daily_packet.rb
+++ b/app/models/daily_packet.rb
@@ -8,9 +8,14 @@ class DailyPacket < ApplicationRecord
   delegate :save_to_disk, :save_to_s3, to: :producer
 
   validates :built_on, presence: true
+  validates :edition_number, presence: true
   validates :feedbin_oldest_ago, presence: true
   validates :feedbin_unread_count, presence: true
   validates :reading_list_pace, presence: true
+
+  def self.next_edition_number
+    (DailyPacket.maximum(:edition_number) || 0) + 1
+  end
 
   def built_on_phrase
     "#{built_on.to_fs}\nweek #{built_on.cweek}"
@@ -25,7 +30,7 @@ class DailyPacket < ApplicationRecord
   end
 
   def headline_phrase
-    "Daily Packet ##{id}"
+    "Daily Packet ##{edition_number}"
   end
 
   def reading_list_phrase

--- a/app/models/daily_packet/builder.rb
+++ b/app/models/daily_packet/builder.rb
@@ -8,6 +8,7 @@ class DailyPacket::Builder
     warm_fuzzy = WarmFuzzy.random
 
     attributes = {
+      edition_number: DailyPacket.next_edition_number,
       feedbin_oldest_ago: feedbin_oldest_ago,
       feedbin_unread_count: feedbin_unread_count,
       reading_list_pace: reading_list.pace,

--- a/db/migrate/20241106215146_add_edition_number_to_daily_packets.rb
+++ b/db/migrate/20241106215146_add_edition_number_to_daily_packets.rb
@@ -1,0 +1,5 @@
+class AddEditionNumberToDailyPackets < ActiveRecord::Migration[7.2]
+  def change
+    add_column :daily_packets, :edition_number, :integer, null: false, default: 0
+  end
+end

--- a/spec/factories/daily_packet.rb
+++ b/spec/factories/daily_packet.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :daily_packet do
     built_on { Date.parse("2007-07-07") }
+    edition_number { 19 }
     feedbin_oldest_ago { 14 }
     feedbin_unread_count { 9 }
     reading_list_pace { 7.7 }

--- a/spec/models/daily_packet/pdf_view_spec.rb
+++ b/spec/models/daily_packet/pdf_view_spec.rb
@@ -15,7 +15,7 @@ describe DailyPacket::PdfView do
       page_one_strings, page_two_strings, page_three_strings = inspector.pages.map { |page| page[:strings] }
 
       expect(page_one_strings).to eq([
-        "DAILY PACKET ##{daily_packet.id}",
+        "DAILY PACKET #19",
         "11/05/2024",
         "week 45",
         "Random Warm Fuzzy",

--- a/spec/models/daily_packet_spec.rb
+++ b/spec/models/daily_packet_spec.rb
@@ -24,4 +24,29 @@ describe DailyPacket do
       expect(daily_packet).to be_valid
     end
   end
+
+  describe ".next_edition_number" do
+    context "with no DailyPacket records" do
+      it "returns 1" do
+        expect(DailyPacket.next_edition_number).to eq 1
+      end
+    end
+
+    context "with a DailyPacket record" do
+      it "returns the edition number after that record's value" do
+        FactoryBot.create(:daily_packet, edition_number: 7)
+        expect(DailyPacket.next_edition_number).to eq 8
+      end
+    end
+
+    context "with a few DailyPacket records" do
+      it "returns the edition number after the record with the highest value" do
+        FactoryBot.create(:daily_packet, edition_number: 1)
+        FactoryBot.create(:daily_packet, edition_number: 7)
+        FactoryBot.create(:daily_packet, edition_number: 3)
+
+        expect(DailyPacket.next_edition_number).to eq 8
+      end
+    end
+  end
 end


### PR DESCRIPTION
I can't fully explain it but the ids on some models have suddenly decided to increment by 33:

```ruby
DailyPacket.pluck(:id)
# => [1, 34, 67]
ActiveRecord::Base.connection.execute("select last_value from daily_packets_id_seq").first["last_value"]
# => 99
```

I did bump into this doc from Heroku:

https://help.heroku.com/PRNW4R5Z/why-are-there-gaps-in-my-postgres-id-sequence

Which is just a general message that these gaps in id sequences are known.

Oddly enough I actually found my exact situation also being discussed here:

https://stackoverflow.com/questions/35579637/gap-in-auto-increment-ids-on-heroku-postgres#comment90515750_35579637

But overall my impression of these discussions is that it's not a good idea to rely on ids like this. What I really should do is have my own field for the edition number of a `DailyPacket` record which is exactly what this PR does.