### PR TITLE
Add star field section separator

### DIFF
--- a/app/models/daily_packet/pdf_view.rb
+++ b/app/models/daily_packet/pdf_view.rb
@@ -44,6 +44,20 @@ class DailyPacket::PdfView < ActiveRecord::AssociatedObject
 
       move_down 20
 
+      bounding_box([0, cursor], width: bounds.width, height: 40) do
+        stroke_bounds
+        star_count = Random.rand(20..50)
+        gap_size = 6
+        star_count.times do
+          star_size = Random.rand(1..4)
+          star_x = Random.rand(gap_size..(bounds.width - gap_size))
+          star_y = Random.rand(gap_size..(bounds.height - gap_size))
+          fill_rectangle [star_x, star_y], star_size, star_size
+        end
+      end
+
+      move_down 20
+
       text "Reading Pace", style: :bold, size: 20
       text daily_packet.reading_list_phrase, size: 12
 


### PR DESCRIPTION
This PR adds a little fun to the Daily Packet - looks like this:

![Screenshot 2024-11-07 at 7 55 19 AM](https://github.com/user-attachments/assets/9045db6c-e7ca-4114-9ef3-4252da83341a)

The idea is to separate two sections by adding a visual element. In this case that visual element is a random sprinkling of dots on a white background.