### PR TITLE
Display random warm fuzzy screenshots

### DIFF
--- a/app/models/daily_packet/pdf_view.rb
+++ b/app/models/daily_packet/pdf_view.rb
@@ -41,7 +41,15 @@ class DailyPacket::PdfView < ActiveRecord::AssociatedObject
 
       warm_fuzzy = daily_packet.warm_fuzzy
       text warm_fuzzy.title, size: 12
-      text warm_fuzzy.body, size: 12
+
+      if warm_fuzzy.body.present?
+        text warm_fuzzy.body, size: 12
+      elsif warm_fuzzy.screenshot.representable?
+        image_data = warm_fuzzy.screenshot.download
+        image_io = StringIO.new(image_data)
+        image image_io, width: bounds.width
+      end
+
       text "\n- #{warm_fuzzy.author}, #{warm_fuzzy.received_at.to_date.to_fs}", size: 12, align: :right
 
       move_down 20

--- a/app/views/fuzzies/index.html.haml
+++ b/app/views/fuzzies/index.html.haml
@@ -3,7 +3,7 @@
 - fuzzies.each do |fuzzy|
   %h2.mb-0= fuzzy.title
   %p from #{fuzzy.author} on #{fuzzy.received_at.to_fs}
-  - if fuzzy.body
+  - if fuzzy.body.present?
     %blockquote
       :markdown
         #{fuzzy.body}


### PR DESCRIPTION
This PR adds a path for `WarmFuzzy` records that have screenshots. In that case the body is set to empty string and so we can render the image using Prawn. To do this we first download the binary image data, then create a `StringIO` object and pass that to the `image` method so that it's included in the PDF:

```ruby
image_data = warm_fuzzy.screenshot.download
image_io = StringIO.new(image_data)
image image_io
```

And that's actually about it! I am passing `width: bounds.width` so that the image takes up the width of the column. This is pretty hard to test or even just QA locally so I'm kinda flying blind with this one. Once it's merged and deployed to production then I will manually generate a daily packet and see if I can verify that everything is good. 🤞 