### PR TITLE
Ensure lineup for tomorrow

### DIFF
--- a/app/jobs/create_lineup_job.rb
+++ b/app/jobs/create_lineup_job.rb
@@ -1,7 +1,6 @@
 class CreateLineupJob < ApplicationJob
   def perform
-    while Lineup.current.nil?
-      Lineup.create_next
-    end
+    Lineup.create_next while Lineup.current.nil?
+    Lineup.create_next
   end
 end

--- a/spec/jobs/create_lineup_job_spec.rb
+++ b/spec/jobs/create_lineup_job_spec.rb
@@ -1,15 +1,27 @@
 require "rails_helper"
 
 describe CreateLineupJob do
+  context "when there is a current Lineup" do
+    let(:current_on) { Date.today }
+
+    it "creates a Lineup for tomorrow" do
+      FactoryBot.create(:lineup, current_on: current_on)
+      expect(Lineup.current).to_not be_nil
+      expect do
+        CreateLineupJob.new.perform
+      end.to change(Lineup, :count).from(1).to(2)
+    end
+  end
+
   context "when there is a Lineup from yesterday" do
     let(:current_on) { Date.yesterday }
 
-    it "creates a Lineup for today" do
+    it "creates a Lineup for today and tomorrow" do
       FactoryBot.create(:lineup, current_on: current_on)
       expect(Lineup.current).to be_nil
       expect do
         CreateLineupJob.new.perform
-      end.to change(Lineup, :count).from(1).to(2)
+      end.to change(Lineup, :count).from(1).to(3)
       expect(Lineup.current).to_not be_nil
     end
   end
@@ -22,7 +34,7 @@ describe CreateLineupJob do
       expect(Lineup.current).to be_nil
       expect do
         CreateLineupJob.new.perform
-      end.to change(Lineup, :count).from(1).to(8)
+      end.to change(Lineup, :count).from(1).to(9)
       expect(Lineup.current).to_not be_nil
     end
   end


### PR DESCRIPTION
I've noticed a pretty consistent pattern on Honeybadger that around 6pm errors start because there isn't a current Lineup record. I think this happens because the server is on UTC and at this time the day flips over. So my solution to this gap is that rather than ensure there's just a current lineup record I'll also ensure there's a lineup record for "tomorrow" which should mean when the day flips over then there's still a current record.