### PR TITLE
Add link to dashboard in footer

### DIFF
--- a/app/views/layouts/_shared_main.html.haml
+++ b/app/views/layouts/_shared_main.html.haml
@@ -7,4 +7,6 @@
     .flash.bg-dark-gray.border-purple
       %p.notice= flash[:notice]
   = yield
-%footer= yield :footer
+- if admin?
+  %footer.border-t-8.border-dark-gray.text-center
+    %p= link_to "dashboard", dashboard_path


### PR DESCRIPTION
Just a lil PR to add a link to the dashboard in the footer. This came up when I added Monolithium as an item in the macOS dock. Now I want to be able to click back to the dashboard.