### PR TITLE
Only use selenium when js is required

### DIFF
--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -23,14 +23,15 @@ RSpec.configure do |config|
   end
 
   config.before(:each, type: :system) do
-    Selenium::WebDriver.logger.ignore(:deprecations)
-    Capybara.server = :puma, {Silent: true}
-    driven_by :selenium, using: :headless_chrome
+    driven_by :rack_test
+  end
+
+  config.before(:each, type: :system, js: true) do
+    driven_by :selenium_chrome_headless
   end
 end
 
 Capybara.configure do |config|
-  config.default_set_options = {clear: :backspace}
   config.exact_text = true
 end
 

--- a/spec/system/crud/books/admin_deletes_book_spec.rb
+++ b/spec/system/crud/books/admin_deletes_book_spec.rb
@@ -5,7 +5,7 @@ describe "Admin deletes book" do
 
   let(:book) { FactoryBot.create(:book) }
 
-  scenario "cancels delete" do
+  scenario "cancels delete", js: true do
     visit "/crud/books/#{book.id}"
 
     dismiss_confirm { click_on "Delete Book" }
@@ -14,7 +14,7 @@ describe "Admin deletes book" do
     expect(page).to have_current_path crud_book_path(book)
   end
 
-  scenario "confirms delete" do
+  scenario "confirms delete", js: true do
     visit "/crud/books/#{book.id}"
 
     accept_confirm { click_on "Delete Book" }

--- a/spec/system/crud/csv_uploads/admin_creates_csv_upload_spec.rb
+++ b/spec/system/crud/csv_uploads/admin_creates_csv_upload_spec.rb
@@ -11,7 +11,7 @@ describe "Admin creates csv upload" do
     expect(page).to have_current_path new_crud_csv_upload_path
   end
 
-  scenario "create with parser error" do
+  scenario "create with parser error", js: true do
     visit "/crud/csv_uploads/new"
     click_on "create"
     select = page.find("#csv_upload_parser_class_name")
@@ -19,7 +19,7 @@ describe "Admin creates csv upload" do
     expect(error_message).to eq "Please select an item in the list."
   end
 
-  scenario "create with file error" do
+  scenario "create with file error", js: true do
     visit "/crud/csv_uploads/new"
     select "WellsFargoParser", from: "csv_upload_parser_class_name"
     click_on "create"

--- a/spec/system/crud/csv_uploads/admin_deletes_csv_upload_spec.rb
+++ b/spec/system/crud/csv_uploads/admin_deletes_csv_upload_spec.rb
@@ -5,7 +5,7 @@ describe "Admin deletes csv upload" do
 
   let(:csv_upload) { FactoryBot.create(:csv_upload) }
 
-  scenario "cancels delete" do
+  scenario "cancels delete", js: true do
     visit "/crud/csv_uploads/#{csv_upload.id}"
 
     dismiss_confirm { click_on "Delete CSV Upload" }
@@ -14,7 +14,7 @@ describe "Admin deletes csv upload" do
     expect(page).to have_current_path crud_csv_upload_path(csv_upload)
   end
 
-  scenario "confirms delete" do
+  scenario "confirms delete", js: true do
     visit "/crud/csv_uploads/#{csv_upload.id}"
 
     accept_confirm { click_on "Delete CSV Upload" }

--- a/spec/system/crud/financial_accounts/admin_creates_financial_account_spec.rb
+++ b/spec/system/crud/financial_accounts/admin_creates_financial_account_spec.rb
@@ -11,7 +11,7 @@ describe "Admin creates financial account" do
     expect(page).to have_current_path new_crud_financial_account_path
   end
 
-  scenario "create with category error" do
+  scenario "create with category error", js: true do
     visit "/crud/financial_accounts/new"
     click_on "create"
     select = page.find("#financial_account_category")

--- a/spec/system/crud/financial_accounts/admin_deletes_financial_account_spec.rb
+++ b/spec/system/crud/financial_accounts/admin_deletes_financial_account_spec.rb
@@ -5,7 +5,7 @@ describe "Admin deletes financial account" do
 
   let(:financial_account) { FactoryBot.create(:financial_account) }
 
-  scenario "cancels delete" do
+  scenario "cancels delete", js: true do
     visit "/crud/financial_accounts/#{financial_account.id}"
 
     dismiss_confirm { click_on "Delete Financial Account" }
@@ -14,7 +14,7 @@ describe "Admin deletes financial account" do
     expect(page).to have_current_path crud_financial_account_path(financial_account)
   end
 
-  scenario "confirms delete" do
+  scenario "confirms delete", js: true do
     visit "/crud/financial_accounts/#{financial_account.id}"
 
     accept_confirm { click_on "Delete Financial Account" }

--- a/spec/system/crud/financial_statements/admin_deletes_financial_account_spec.rb
+++ b/spec/system/crud/financial_statements/admin_deletes_financial_account_spec.rb
@@ -8,7 +8,7 @@ describe "Admin deletes financial statement" do
     FactoryBot.create(:financial_statement, financial_account: financial_account)
   end
 
-  scenario "cancels delete" do
+  scenario "cancels delete", js: true do
     visit "/crud/financial_accounts/#{financial_account.id}/financial_statements/#{financial_statement.id}"
 
     dismiss_confirm { click_on "Delete Financial Statement" }
@@ -17,7 +17,7 @@ describe "Admin deletes financial statement" do
     expect(page).to have_current_path crud_financial_account_financial_statement_path(financial_account, financial_statement)
   end
 
-  scenario "confirms delete" do
+  scenario "confirms delete", js: true do
     visit "/crud/financial_accounts/#{financial_account.id}/financial_statements/#{financial_statement.id}"
 
     accept_confirm { click_on "Delete Financial Statement" }

--- a/spec/system/crud/gift_ideas/admin_deletes_gift_idea_spec.rb
+++ b/spec/system/crud/gift_ideas/admin_deletes_gift_idea_spec.rb
@@ -5,7 +5,7 @@ describe "Admin deletes gift idea" do
 
   let(:gift_idea) { FactoryBot.create(:gift_idea) }
 
-  scenario "cancels delete" do
+  scenario "cancels delete", js: true do
     visit "/crud/gift_ideas/#{gift_idea.id}"
 
     dismiss_confirm { click_on "Delete Gift Idea" }
@@ -14,7 +14,7 @@ describe "Admin deletes gift idea" do
     expect(page).to have_current_path crud_gift_idea_path(gift_idea)
   end
 
-  scenario "confirms delete" do
+  scenario "confirms delete", js: true do
     visit "/crud/gift_ideas/#{gift_idea.id}"
 
     accept_confirm { click_on "Delete Gift Idea" }

--- a/spec/system/crud/post_bin_requests/admin_deletes_post_bin_request_spec.rb
+++ b/spec/system/crud/post_bin_requests/admin_deletes_post_bin_request_spec.rb
@@ -5,7 +5,7 @@ describe "Admin deletes post bin request" do
 
   let(:post_bin_request) { FactoryBot.create(:post_bin_request) }
 
-  scenario "cancels delete" do
+  scenario "cancels delete", js: true do
     visit "/crud/post_bin_requests/#{post_bin_request.id}"
 
     dismiss_confirm { click_on "Delete Post Bin Request" }
@@ -14,7 +14,7 @@ describe "Admin deletes post bin request" do
     expect(page).to have_current_path crud_post_bin_request_path(post_bin_request)
   end
 
-  scenario "confirms delete" do
+  scenario "confirms delete", js: true do
     visit "/crud/post_bin_requests/#{post_bin_request.id}"
 
     accept_confirm { click_on "Delete Post Bin Request" }

--- a/spec/system/crud/projects/admin_deletes_project_spec.rb
+++ b/spec/system/crud/projects/admin_deletes_project_spec.rb
@@ -5,7 +5,7 @@ describe "Admin deletes project" do
 
   let(:project) { FactoryBot.create(:project) }
 
-  scenario "cancels delete" do
+  scenario "cancels delete", js: true do
     visit "/crud/projects/#{project.id}"
 
     dismiss_confirm { click_on "Delete Project" }
@@ -14,7 +14,7 @@ describe "Admin deletes project" do
     expect(page).to have_current_path crud_project_path(project)
   end
 
-  scenario "confirms delete" do
+  scenario "confirms delete", js: true do
     visit "/crud/projects/#{project.id}"
 
     accept_confirm { click_on "Delete Project" }

--- a/spec/system/crud/raw_hooks/admin_deletes_raw_hook_spec.rb
+++ b/spec/system/crud/raw_hooks/admin_deletes_raw_hook_spec.rb
@@ -5,7 +5,7 @@ describe "Admin deletes raw hook" do
 
   let(:raw_hook) { FactoryBot.create(:raw_hook) }
 
-  scenario "cancels delete" do
+  scenario "cancels delete", js: true do
     visit "/crud/raw_hooks/#{raw_hook.id}"
 
     dismiss_confirm { click_on "Delete Raw Hook" }
@@ -14,7 +14,7 @@ describe "Admin deletes raw hook" do
     expect(page).to have_current_path crud_raw_hook_path(raw_hook)
   end
 
-  scenario "confirms delete" do
+  scenario "confirms delete", js: true do
     visit "/crud/raw_hooks/#{raw_hook.id}"
 
     accept_confirm { click_on "Delete Raw Hook" }

--- a/spec/system/crud/sneakers/admin_deletes_sneaker_spec.rb
+++ b/spec/system/crud/sneakers/admin_deletes_sneaker_spec.rb
@@ -5,7 +5,7 @@ describe "Admin deletes sneaker" do
 
   let(:sneaker) { FactoryBot.create(:sneaker) }
 
-  scenario "cancels delete" do
+  scenario "cancels delete", js: true do
     visit "/crud/sneakers/#{sneaker.id}"
 
     dismiss_confirm { click_on "Delete Sneaker" }
@@ -14,7 +14,7 @@ describe "Admin deletes sneaker" do
     expect(page).to have_current_path crud_sneaker_path(sneaker)
   end
 
-  scenario "confirms delete" do
+  scenario "confirms delete", js: true do
     visit "/crud/sneakers/#{sneaker.id}"
 
     accept_confirm { click_on "Delete Sneaker" }

--- a/spec/system/crud/warm_fuzzies/admin_deletes_warm_fuzzy_spec.rb
+++ b/spec/system/crud/warm_fuzzies/admin_deletes_warm_fuzzy_spec.rb
@@ -5,7 +5,7 @@ describe "Admin deletes warm fuzzy" do
 
   let(:warm_fuzzy) { FactoryBot.create(:warm_fuzzy) }
 
-  scenario "cancels delete" do
+  scenario "cancels delete", js: true do
     visit "/crud/warm_fuzzies/#{warm_fuzzy.id}"
 
     dismiss_confirm { click_on "Delete Warm Fuzzy" }
@@ -14,7 +14,7 @@ describe "Admin deletes warm fuzzy" do
     expect(page).to have_current_path crud_warm_fuzzy_path(warm_fuzzy)
   end
 
-  scenario "confirms delete" do
+  scenario "confirms delete", js: true do
     visit "/crud/warm_fuzzies/#{warm_fuzzy.id}"
 
     accept_confirm { click_on "Delete Warm Fuzzy" }

--- a/spec/system/crud/webhook_senders/admin_deletes_webhook_sender_spec.rb
+++ b/spec/system/crud/webhook_senders/admin_deletes_webhook_sender_spec.rb
@@ -5,7 +5,7 @@ describe "Admin deletes webhook sender" do
 
   let(:webhook_sender) { FactoryBot.create(:webhook_sender) }
 
-  scenario "cancels delete" do
+  scenario "cancels delete", js: true do
     visit "/crud/webhook_senders/#{webhook_sender.id}"
 
     dismiss_confirm { click_on "Delete Webhook Sender" }
@@ -14,7 +14,7 @@ describe "Admin deletes webhook sender" do
     expect(page).to have_current_path crud_webhook_sender_path(webhook_sender)
   end
 
-  scenario "confirms delete" do
+  scenario "confirms delete", js: true do
     visit "/crud/webhook_senders/#{webhook_sender.id}"
 
     accept_confirm { click_on "Delete Webhook Sender" }


### PR DESCRIPTION
I was reading this one:

https://thoughtbot.com/blog/migrating-from-feature-specs-to-system-specs

Which mentioned this one:

https://thoughtbot.com/blog/rack_test-or-selenium

And suddenly I realized that I was slowing down the system tests in this app by only ever using selenium! So this PR switches things around so that only tests annotated with `js: true` will run with headless selenium. The default will be rack test and I'm def seeing the full suite of tests running much faster!