### PR TITLE
Extract enhancer object and add format to book

### DIFF
--- a/app/controllers/crud/books_controller.rb
+++ b/app/controllers/crud/books_controller.rb
@@ -38,6 +38,6 @@ class Crud::BooksController < ApplicationController
   private
 
   def book_params
-    params.require(:book).permit(:finished_on, :isbn, :pages, :title)
+    params.require(:book).permit(:finished_on, :format, :isbn, :pages, :title)
   end
 end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,4 +1,14 @@
 module ApplicationHelper
+  def book_format_options
+    placeholder_option = [["please select", ""]]
+
+    format_options = Book::FORMATS.map do |format|
+      [format, format]
+    end
+
+    placeholder_option + format_options
+  end
+
   def last_week_path(work_week)
     target_date = work_week.target_date - 1.week
     target = TargetSlug.for(target_date)

--- a/app/jobs/enhance_book_job.rb
+++ b/app/jobs/enhance_book_job.rb
@@ -1,8 +1,8 @@
 class EnhanceBookJob < ApplicationJob
   def perform(book_id)
-    book = Book.find(book_id)
+    book = Book.find_by(id: book_id)
     return unless book
 
-    book.enhance!
+    book.enhancer.update_from_api
   end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -1,6 +1,9 @@
 class Book < ApplicationRecord
-  validates :isbn, presence: true
+  FORMATS = %w[print audio kindle]
+
   validates :finished_on, presence: true
+  validates :format, inclusion: {in: FORMATS}
+  validates :isbn, presence: true
 
   has_object :enhancer
 
@@ -9,6 +12,7 @@ class Book < ApplicationRecord
       ["ISBN", isbn],
       ["Title", title],
       ["Pages", pages],
+      ["Format", format],
       ["Finished On", finished_on.to_fs],
       ["Created At", created_at.to_fs],
       ["Updated At", updated_at.to_fs]

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -2,17 +2,7 @@ class Book < ApplicationRecord
   validates :isbn, presence: true
   validates :finished_on, presence: true
 
-  def enhance!
-    open_data = OpenLibraryApi.get_book(isbn)
-    return unless open_data
-
-    open_attrs = {
-      isbn: open_data["isbn_13"].first,
-      pages: open_data["number_of_pages"],
-      title: open_data["title"]
-    }
-    update!(open_attrs)
-  end
+  has_object :enhancer
 
   def table_attrs
     [

--- a/app/models/book/enhancer.rb
+++ b/app/models/book/enhancer.rb
@@ -1,0 +1,14 @@
+class Book::Enhancer < ActiveRecord::AssociatedObject
+  def update_from_api
+    api_data = OpenLibraryApi.get_book(book.isbn)
+    return unless api_data
+
+    attrs = {
+      isbn: api_data["isbn_13"].first,
+      pages: api_data["number_of_pages"],
+      title: api_data["title"]
+    }
+
+    book.update!(attrs)
+  end
+end

--- a/app/models/book/enhancer.rb
+++ b/app/models/book/enhancer.rb
@@ -5,11 +5,14 @@ class Book::Enhancer < ActiveRecord::AssociatedObject
     api_data = OpenLibraryApi.get_book(book.isbn)
     return unless api_data
 
+    isbns = api_data["isbn_13"] || []
+
     attrs = {
-      isbn: api_data["isbn_13"].first,
+      isbn: isbns.first,
       pages: api_data["number_of_pages"],
       title: api_data["title"]
-    }
+    }.compact
+    return unless attrs.any?
 
     book.update!(attrs)
   end

--- a/app/models/book/enhancer.rb
+++ b/app/models/book/enhancer.rb
@@ -1,5 +1,7 @@
 class Book::Enhancer < ActiveRecord::AssociatedObject
   def update_from_api
+    return if book.isbn == "none"
+
     api_data = OpenLibraryApi.get_book(book.isbn)
     return unless api_data
 

--- a/app/views/crud/books/edit.html.haml
+++ b/app/views/crud/books/edit.html.haml
@@ -6,5 +6,6 @@
   = form.text_field :isbn, placeholder: "isbn"
   = form.text_field :title, placeholder: "title"
   = form.text_field :pages, placeholder: "pages"
+  = form.select :format, book_format_options, selected: book.format
   = form.date_field :finished_on, placeholder: "finished on"
   = form.button "update"

--- a/app/views/crud/books/new.html.haml
+++ b/app/views/crud/books/new.html.haml
@@ -4,5 +4,6 @@
 
 = form_with model: [:crud, book] do |form|
   = form.text_field :isbn, placeholder: "isbn"
+  = form.select :format, book_format_options, selected: book.format
   = form.date_field :finished_on, placeholder: "finished on"
   = form.button "create"

--- a/db/migrate/20241222195354_add_format_to_books.rb
+++ b/db/migrate/20241222195354_add_format_to_books.rb
@@ -1,0 +1,11 @@
+class AddFormatToBooks < ActiveRecord::Migration[8.0]
+  def up
+    add_column :books, :format, :string
+    Book.update_all(format: "print")
+    change_column_null :books, :format, false
+  end
+
+  def down
+    remove_column :books, :format
+  end
+end

--- a/spec/factories/book.rb
+++ b/spec/factories/book.rb
@@ -1,6 +1,7 @@
 FactoryBot.define do
   factory :book do
     finished_on { Time.now }
+    format { "print" }
     isbn { "123" }
     pages { "100" }
 

--- a/spec/jobs/enhance_book_job_spec.rb
+++ b/spec/jobs/enhance_book_job_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+describe EnhanceBookJob do
+  context "with an invalid book_id" do
+    let(:book_id) { "invalid" }
+
+    it "does nothing" do
+      expect do
+        EnhanceBookJob.new.perform(book_id)
+      end.to_not raise_error
+    end
+  end
+
+  context "with a valid book_id" do
+    let(:book_id) { FactoryBot.create(:book).id }
+
+    it "enhances that book with api data" do
+      expect_any_instance_of(Book::Enhancer).to receive(:update_from_api).and_return(nil)
+      EnhanceBookJob.new.perform(book_id)
+    end
+  end
+end

--- a/spec/models/book/enhancer_spec.rb
+++ b/spec/models/book/enhancer_spec.rb
@@ -5,23 +5,34 @@ describe Book::Enhancer do
     let(:book) do
       FactoryBot.create(
         :book,
-        isbn: "123456789",
+        isbn: isbn,
         pages: nil,
         title: nil
       )
     end
 
-    before do
-      expect(OpenLibraryApi).to receive(:get_book).and_return(api_data)
-    end
-
     context "with nil api data" do
       let(:api_data) { nil }
+      let(:isbn) { "123456789" }
 
       it "does nothing" do
+        expect(OpenLibraryApi).to receive(:get_book).and_return(api_data)
         book.enhancer.update_from_api
 
         expect(book.isbn).to eq "123456789"
+        expect(book.pages).to eq nil
+        expect(book.title).to eq nil
+      end
+    end
+
+    context "with a book that has none for isbn" do
+      let(:isbn) { "none" }
+
+      it "does nothing" do
+        expect(OpenLibraryApi).to_not receive(:get_book)
+        book.enhancer.update_from_api
+
+        expect(book.isbn).to eq "none"
         expect(book.pages).to eq nil
         expect(book.title).to eq nil
       end
@@ -36,7 +47,10 @@ describe Book::Enhancer do
         }
       end
 
+      let(:isbn) { "123456789" }
+
       it "updates the book with that api data" do
+        expect(OpenLibraryApi).to receive(:get_book).and_return(api_data)
         book.enhancer.update_from_api
 
         expect(book.isbn).to eq "123-456-789"

--- a/spec/models/book/enhancer_spec.rb
+++ b/spec/models/book/enhancer_spec.rb
@@ -25,6 +25,20 @@ describe Book::Enhancer do
       end
     end
 
+    context "with empty api data" do
+      let(:api_data) { {} }
+      let(:isbn) { "123456789" }
+
+      it "does nothing" do
+        expect(OpenLibraryApi).to receive(:get_book).and_return(api_data)
+        book.enhancer.update_from_api
+
+        expect(book.isbn).to eq "123456789"
+        expect(book.pages).to eq nil
+        expect(book.title).to eq nil
+      end
+    end
+
     context "with a book that has none for isbn" do
       let(:isbn) { "none" }
 

--- a/spec/models/book/enhancer_spec.rb
+++ b/spec/models/book/enhancer_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+describe Book::Enhancer do
+  describe "#update_from_api" do
+    let(:book) do
+      FactoryBot.create(
+        :book,
+        isbn: "123456789",
+        pages: nil,
+        title: nil
+      )
+    end
+
+    before do
+      expect(OpenLibraryApi).to receive(:get_book).and_return(api_data)
+    end
+
+    context "with nil api data" do
+      let(:api_data) { nil }
+
+      it "does nothing" do
+        book.enhancer.update_from_api
+
+        expect(book.isbn).to eq "123456789"
+        expect(book.pages).to eq nil
+        expect(book.title).to eq nil
+      end
+    end
+
+    context "with complete api data" do
+      let(:api_data) do
+        {
+          "isbn_13" => ["123-456-789"],
+          "number_of_pages" => 7,
+          "title" => "Very Short Book"
+        }
+      end
+
+      it "updates the book with that api data" do
+        book.enhancer.update_from_api
+
+        expect(book.isbn).to eq "123-456-789"
+        expect(book.pages).to eq 7
+        expect(book.title).to eq "Very Short Book"
+      end
+    end
+  end
+end

--- a/spec/system/crud/books/admin_creates_book_spec.rb
+++ b/spec/system/crud/books/admin_creates_book_spec.rb
@@ -14,13 +14,14 @@ describe "Admin creates book" do
   scenario "create with errors" do
     visit "/crud/books/new"
     click_on "create"
-    expect(page).to have_css ".alert", text: "Isbn can't be blank and Finished on can't be blank"
+    expect(page).to have_css ".alert", text: "Finished on can't be blank, Format is not included in the list, and Isbn can't be blank"
     expect(page).to have_current_path new_crud_book_path
   end
 
   scenario "create successfully" do
     visit "/crud/books/new"
     fill_in "isbn", with: "abc-123"
+    select "print", from: "book_format"
     fill_in "finished on", with: "01/01/2000"
     click_on "create"
 
@@ -40,6 +41,7 @@ describe "Admin creates book" do
         ["ISBN", "abc-123"],
         ["Title", ""],
         ["Pages", ""],
+        ["Format", "print"],
         ["Finished On", "01/01/2000"],
         ["Created At", book.created_at.to_fs],
         ["Updated At", book.updated_at.to_fs]

--- a/spec/system/crud/books/admin_views_book_spec.rb
+++ b/spec/system/crud/books/admin_views_book_spec.rb
@@ -32,6 +32,7 @@ describe "Admin views book" do
         ["ISBN", "abc-123"],
         ["Title", "Whittling And You"],
         ["Pages", "777"],
+        ["Format", "print"],
         ["Finished On", book.finished_on.to_fs],
         ["Created At", book.created_at.to_fs],
         ["Updated At", book.updated_at.to_fs]


### PR DESCRIPTION
This PR starts out by extracting an Associated Object for `Book` called `Book::Enhancer` to encapsulate the logic around updating the record with API data. More tests were added especially around the sad path. While I was at it I added a special case for `none` isbn values. When that's the isbn value then I skip enhancing at all.

I also added a `format` field that supports these values:

* print
* audio
* kindle

I'm not sure I'll use it much but this way I can keep track of how I read a given book.