### PR TITLE
Reorganize Daily Packet pages

### DIFF
--- a/app/models/daily_packet/pdf_view.rb
+++ b/app/models/daily_packet/pdf_view.rb
@@ -16,13 +16,11 @@ class DailyPacket::PdfView < ActiveRecord::AssociatedObject
     stroke_color "000000"
     draw_front_page
     start_new_page
-    draw_top_three_page
-    start_new_page
+    draw_personal_page
     unless daily_packet.built_on_weekend?
-      draw_start_stop_list_page
       start_new_page
+      draw_work_page
     end
-    draw_chore_list_page
   end
 
   def draw_front_page
@@ -81,7 +79,7 @@ class DailyPacket::PdfView < ActiveRecord::AssociatedObject
     end
   end
 
-  def draw_top_three_page
+  def draw_personal_page
     text "Top 3: Personal".upcase, style: :bold_italic, size: 42
 
     move_up 12
@@ -100,29 +98,44 @@ class DailyPacket::PdfView < ActiveRecord::AssociatedObject
       text "3."
     end
 
-    unless daily_packet.built_on_weekend?
-      move_cursor_to bounds.top / 2
-      text "Top 3: Work".upcase, style: :bold_italic, size: 42
+    move_cursor_to bounds.top / 2
 
-      move_up 12
+    text "Chore List".upcase, style: :bold_italic, size: 42
 
-      stroke do
-        horizontal_rule
-      end
+    move_up 12
 
-      move_down 20
+    stroke do
+      horizontal_rule
+    end
 
-      font_size(20) do
-        text "1."
-        move_down 10
-        text "2."
-        move_down 10
-        text "3."
-      end
+    move_down 20
+
+    daily_packet.chore_list.each do |chore|
+      text chore, size: 14
     end
   end
 
-  def draw_start_stop_list_page
+  def draw_work_page
+    text "Top 3: Work".upcase, style: :bold_italic, size: 42
+
+    move_up 12
+
+    stroke do
+      horizontal_rule
+    end
+
+    move_down 20
+
+    font_size(20) do
+      text "1."
+      move_down 10
+      text "2."
+      move_down 10
+      text "3."
+    end
+
+    move_cursor_to (bounds.top / 3) * 2
+
     text "Start List".upcase, style: :bold_italic, size: 42
 
     move_up 12
@@ -137,7 +150,7 @@ class DailyPacket::PdfView < ActiveRecord::AssociatedObject
       text item, size: 14
     end
 
-    move_cursor_to bounds.top / 2
+    move_cursor_to bounds.top / 3
 
     text "Stop List".upcase, style: :bold_italic, size: 42
 
@@ -151,22 +164,6 @@ class DailyPacket::PdfView < ActiveRecord::AssociatedObject
 
     daily_packet.stop_list.each do |item|
       text item, size: 14
-    end
-  end
-
-  def draw_chore_list_page
-    text "Chore List".upcase, style: :bold_italic, size: 42
-
-    move_up 12
-
-    stroke do
-      horizontal_rule
-    end
-
-    move_down 20
-
-    daily_packet.chore_list.each do |chore|
-      text chore, size: 14
     end
   end
 end

--- a/spec/models/daily_packet/pdf_view_spec.rb
+++ b/spec/models/daily_packet/pdf_view_spec.rb
@@ -14,7 +14,7 @@ describe DailyPacket::PdfView do
       let(:built_on) { Date.parse("2024-11-05") }
 
       it "renders the document" do
-        expect(inspector.pages.size).to eq 4
+        expect(inspector.pages.size).to eq 3
 
         expect(page_one_strings).to eq([
           "DAILY PACKET #19",
@@ -36,13 +36,20 @@ describe DailyPacket::PdfView do
           "1.",
           "2.",
           "3.",
-          "TOP 3: WORK",
-          "1.",
-          "2.",
-          "3."
+          "CHORE LIST",
+          "unload dishwasher",
+          "defrost meat",
+          "refill soap dispensers",
+          "do hand wash",
+          "wipe off kitchen table",
+          "run dishwasher"
         ])
 
         expect(page_three_strings).to eq([
+          "TOP 3: WORK",
+          "1.",
+          "2.",
+          "3.",
           "START LIST",
           "drill master password",
           "open dashboards",
@@ -52,58 +59,26 @@ describe DailyPacket::PdfView do
           "plug in mouse",
           "say bye in Slack"
         ])
-
-        expect(page_four_strings).to eq([
-          "CHORE LIST",
-          "unload dishwasher",
-          "defrost meat",
-          "refill soap dispensers",
-          "do hand wash",
-          "wipe off kitchen table",
-          "run dishwasher"
-        ])
       end
     end
   end
 
-  describe "top three page" do
+  describe "work page" do
     context "on a Saturday" do
       let(:built_on) { Date.parse("2024-11-09") }
 
-      it "does not render the work top three section" do
-        expect(page_two_strings).to_not include "TOP 3: WORK"
+      it "does not render the work page" do
+        expect(inspector.pages.size).to eq 2
       end
     end
   end
 
-  describe "start/stop list page" do
-    context "on a Monday" do
-      let(:built_on) { Date.parse("2024-11-04") }
-
-      it "renders the start/stop list page" do
-        expect(inspector.pages.size).to eq 4
-        expect(page_three_strings).to include "START LIST"
-        expect(page_three_strings).to include "STOP LIST"
-      end
-    end
-
-    context "on a Saturday" do
-      let(:built_on) { Date.parse("2024-11-09") }
-
-      it "suppresses the start/stop list page" do
-        expect(inspector.pages.size).to eq 3
-        expect(page_three_strings).to_not include "START LIST"
-        expect(page_three_strings).to_not include "STOP LIST"
-      end
-    end
-  end
-
-  describe "chore list page" do
+  describe "chore list section" do
     context "on a Monday" do
       let(:built_on) { Date.parse("2024-11-04") }
 
       it "renders the Monday-specific chore" do
-        expect(page_four_strings).to include "put out garbage cans"
+        expect(page_two_strings).to include "put out garbage cans"
       end
     end
 
@@ -111,9 +86,9 @@ describe DailyPacket::PdfView do
       let(:built_on) { Date.parse("2024-11-09") }
 
       it "renders the Weekend-specific chore but not the summertime ones" do
-        expect(page_three_strings).to include "collect laundry"
+        expect(page_two_strings).to include "collect laundry"
 
-        expect(page_three_strings).to_not include(
+        expect(page_two_strings).to_not include(
           "poop patrol",
           "mow front",
           "mow back",
@@ -126,7 +101,7 @@ describe DailyPacket::PdfView do
       let(:built_on) { Date.parse("2024-07-13") }
 
       it "renders the summertime Weekend-specific chores" do
-        expect(page_three_strings).to include(
+        expect(page_two_strings).to include(
           "poop patrol",
           "mow front",
           "mow back",


### PR DESCRIPTION
This PR reorganizes the Daily Packet pages so that all the personal stuff is on one page and the work stuff on another. I was finding that mixing personal/work items was actually annoying and I ended up wasting a piece of paper.