### PR TITLE
Return new artworks from MarketingCollections

### DIFF
--- a/app/models/marketing_collections.rb
+++ b/app/models/marketing_collections.rb
@@ -18,14 +18,14 @@ class MarketingCollections
       edges.map { |edge| edge["node"] }
     end.flatten
 
-    return unless payloads.any?
+    return [] unless payloads.any?
 
     existing_gravity_ids = Artwork.pluck(:gravity_id)
 
-    payloads.each do |payload|
+    payloads.map do |payload|
       next if existing_gravity_ids.include?(payload["gravity_id"])
 
       Artwork.create(gravity_id: payload["gravity_id"], payload: payload)
-    end
+    end.compact
   end
 end

--- a/spec/models/marketing_collections_spec.rb
+++ b/spec/models/marketing_collections_spec.rb
@@ -16,10 +16,8 @@ describe MarketingCollections do
 
       it "does nothing" do
         expect(Artwork).to_not receive(:pluck).with(:gravity_id)
-
-        expect do
-          MarketingCollections.load_artworks(slugs)
-        end.to_not change(Artwork, :count)
+        new_artworks = MarketingCollections.load_artworks(slugs)
+        expect(new_artworks).to eq []
       end
     end
 
@@ -45,9 +43,8 @@ describe MarketingCollections do
       end
 
       it "does nothing" do
-        expect do
-          MarketingCollections.load_artworks(slugs)
-        end.to_not change(Artwork, :count)
+        new_artworks = MarketingCollections.load_artworks(slugs)
+        expect(new_artworks).to eq []
       end
     end
 
@@ -71,12 +68,9 @@ describe MarketingCollections do
       end
 
       it "creates an Artwork record" do
-        expect do
-          MarketingCollections.load_artworks(slugs)
-        end.to change(Artwork, :count).by(1)
-
-        new_artwork = Artwork.last
-        expect(new_artwork.gravity_id).to eq "new_gravity_id"
+        new_artworks = MarketingCollections.load_artworks(slugs)
+        expect(new_artworks.count).to eq 1
+        expect(new_artworks.first.gravity_id).to eq "new_gravity_id"
       end
     end
   end


### PR DESCRIPTION
It occurred to me that what I should have been doing here was returning the newly created `Artwork` records. Doing that cleans up the tests and is also handy in a Rails console while playing around.