### PR TITLE
Create tiny script to unfollow artsy projects

### DIFF
--- a/circleci-unfollow/script.rb
+++ b/circleci-unfollow/script.rb
@@ -1,0 +1,22 @@
+# gem install circleci
+
+require "circleci"
+
+CircleCi.configure do |config|
+  config.token = File.read("circleci-unfollow/token.txt")
+end
+
+projects = CircleCi::Projects.new.get.body
+
+artsy_projects = projects.select do |project|
+  project["username"] == "artsy"
+end
+
+puts "#{artsy_projects.count} artsy projects found"
+
+artsy_projects.each do |project|
+  username = project["username"]
+  reponame = project["reponame"]
+  puts "unfollowing #{username}/#{reponame}"
+  CircleCi::Project.new(username, reponame).unfollow
+end


### PR DESCRIPTION
I still get CircleCI notifications for some old Artsy projects. I assumed it would be easy to use their site to remove them but I could not. So I wrote this little script to do it. I'll open this PR so that I have it in case I ever need it again but then I'll remove it when I have a chance.