### PR TITLE
Add REST endpoints for WorkDay model

### DIFF
--- a/app/controllers/api/v1/work_days_controller.rb
+++ b/app/controllers/api/v1/work_days_controller.rb
@@ -10,7 +10,22 @@ module Api
         work_week.work_days
       end
 
+      def create
+        work_day.save!
+        render :show, status: :created
+      end
+
       private
+
+      def work_day_params
+        params.require(:work_day).permit(
+          :adjust_minutes,
+          :date,
+          :in_minutes,
+          :out_minutes,
+          :pto_minutes
+        )
+      end
 
       def ensure_work_week_params
         error = nil

--- a/app/controllers/api/v1/work_days_controller.rb
+++ b/app/controllers/api/v1/work_days_controller.rb
@@ -1,0 +1,23 @@
+module Api
+  module V1
+    class WorkDaysController < Api::V1Controller
+      before_action :ensure_work_week_params, only: :index
+
+      expose(:work_days) do
+        work_week = WorkWeek.find_or_create(params[:year], params[:number])
+        work_week.work_days
+      end
+
+      private
+
+      def ensure_work_week_params
+        error = nil
+        error = "year is required" if params[:year].nil?
+        error = "number is required" if params[:number].nil?
+        return if error.nil?
+
+        render json: {error: error}, status: :bad_request
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/work_days_controller.rb
+++ b/app/controllers/api/v1/work_days_controller.rb
@@ -15,6 +15,11 @@ module Api
         render :show, status: :created
       end
 
+      def update
+        work_day.update!(work_day_params)
+        render :show
+      end
+
       private
 
       def work_day_params

--- a/app/controllers/api/v1/work_days_controller.rb
+++ b/app/controllers/api/v1/work_days_controller.rb
@@ -20,6 +20,11 @@ module Api
         render :show
       end
 
+      def destroy
+        work_day.destroy
+        head :ok
+      end
+
       private
 
       def work_day_params

--- a/app/controllers/api/v1/work_days_controller.rb
+++ b/app/controllers/api/v1/work_days_controller.rb
@@ -3,6 +3,8 @@ module Api
     class WorkDaysController < Api::V1Controller
       before_action :ensure_work_week_params, only: :index
 
+      expose(:work_day, with: :random_or_find)
+
       expose(:work_days) do
         work_week = WorkWeek.find_or_create(params[:year], params[:number])
         work_week.work_days

--- a/app/views/api/v1/work_days/index.json.jbuilder
+++ b/app/views/api/v1/work_days/index.json.jbuilder
@@ -1,0 +1,11 @@
+json.array!(
+  work_days,
+  :adjust_minutes,
+  :created_at,
+  :date,
+  :id,
+  :in_minutes,
+  :out_minutes,
+  :pto_minutes,
+  :updated_at
+)

--- a/app/views/api/v1/work_days/show.json.jbuilder
+++ b/app/views/api/v1/work_days/show.json.jbuilder
@@ -1,0 +1,11 @@
+json.call(
+  work_day,
+  :adjust_minutes,
+  :created_at,
+  :date,
+  :id,
+  :in_minutes,
+  :out_minutes,
+  :pto_minutes,
+  :updated_at
+)

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,7 @@ Rails.application.routes.draw do
   namespace :api, defaults: {format: :json} do
     namespace :v1 do
       resources :books, only: %i[index show create update destroy]
-      resources :work_days, only: %i[index show create]
+      resources :work_days, only: %i[index show create update]
 
       get :decode_jwt, to: "decode_jwt#show"
       get :ping, to: "ping#show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,7 @@ Rails.application.routes.draw do
   namespace :api, defaults: {format: :json} do
     namespace :v1 do
       resources :books, only: %i[index show create update destroy]
-      resources :work_days, only: %i[index show create update]
+      resources :work_days, only: %i[index show create update destroy]
 
       get :decode_jwt, to: "decode_jwt#show"
       get :ping, to: "ping#show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,6 +54,7 @@ Rails.application.routes.draw do
   namespace :api, defaults: {format: :json} do
     namespace :v1 do
       resources :books, only: %i[index show create update destroy]
+      resources :work_days, only: %i[index]
 
       get :decode_jwt, to: "decode_jwt#show"
       get :ping, to: "ping#show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,7 @@ Rails.application.routes.draw do
   namespace :api, defaults: {format: :json} do
     namespace :v1 do
       resources :books, only: %i[index show create update destroy]
-      resources :work_days, only: %i[index show]
+      resources :work_days, only: %i[index show create]
 
       get :decode_jwt, to: "decode_jwt#show"
       get :ping, to: "ping#show"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -54,7 +54,7 @@ Rails.application.routes.draw do
   namespace :api, defaults: {format: :json} do
     namespace :v1 do
       resources :books, only: %i[index show create update destroy]
-      resources :work_days, only: %i[index]
+      resources :work_days, only: %i[index show]
 
       get :decode_jwt, to: "decode_jwt#show"
       get :ping, to: "ping#show"

--- a/spec/requests/api/v1/work_days/create_work_day_spec.rb
+++ b/spec/requests/api/v1/work_days/create_work_day_spec.rb
@@ -1,0 +1,78 @@
+require "rails_helper"
+
+describe "POST /api/v1/work_days" do
+  let(:headers) { {ApiController::CLIENT_TOKEN_HEADER => Monolithium.config.client_token} }
+
+  context "without required param" do
+    let(:params) { {} }
+
+    it "returns 400 and an error message" do
+      post "/api/v1/work_days", params: params, headers: headers
+
+      expect(response.status).to eq 400
+      expect(response.body).to match "param is missing"
+    end
+  end
+
+  context "without required attributes" do
+    let(:params) { {work_day: {foo: :bar}} }
+
+    it "returns 400 and an error message" do
+      post "/api/v1/work_days", params: params, headers: headers
+
+      expect(response.status).to eq 400
+      expect(response.body).to match "Validation failed"
+    end
+  end
+
+  context "with invalid required attributes" do
+    let(:params) { {work_day: {date: "invalid"}} }
+
+    it "returns 400 and an error message" do
+      post "/api/v1/work_days", params: params, headers: headers
+
+      expect(response.status).to eq 400
+      expect(response.body).to match "Validation failed"
+    end
+  end
+
+  context "with valid required attributes" do
+    let(:params) { {work_day: {date: Date.today}} }
+
+    it "returns 201 and the json for the work_day" do
+      post "/api/v1/work_days", params: params, headers: headers
+
+      expect(response.status).to eq 201
+      expect(response.parsed_body).to match({
+        "adjust_minutes" => nil,
+        "created_at" => anything,
+        "date" => Date.today.to_s,
+        "id" => anything,
+        "in_minutes" => nil,
+        "out_minutes" => nil,
+        "pto_minutes" => nil,
+        "updated_at" => anything
+      })
+    end
+  end
+
+  context "with bonus attribute" do
+    let(:zero_time) { Time.at(0).utc }
+
+    let(:params) do
+      {
+        work_day: {
+          created_at: zero_time,
+          date: Date.today
+        }
+      }
+    end
+
+    it "ignores bonus attributes" do
+      post "/api/v1/work_days", params: params, headers: headers
+
+      expect(response.status).to eq 201
+      expect(response.parsed_body["created_at"]).to_not eq zero_time.as_json
+    end
+  end
+end

--- a/spec/requests/api/v1/work_days/destroy_work_day_spec.rb
+++ b/spec/requests/api/v1/work_days/destroy_work_day_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe "DELETE /api/v1/work_days/:id" do
+  let(:headers) { {ApiController::CLIENT_TOKEN_HEADER => Monolithium.config.client_token} }
+
+  context "with an invalid id" do
+    it "returns 404 and an error message" do
+      delete "/api/v1/work_days/invalid", headers: headers
+
+      expect(response.status).to eq 404
+      expect(response.body).to match "Couldn't find WorkDay"
+    end
+  end
+
+  context "with a valid id" do
+    let(:work_day) { FactoryBot.create(:work_day) }
+
+    it "returns 200 and destroys that record" do
+      delete "/api/v1/work_days/#{work_day.id}", headers: headers
+
+      expect(response.status).to eq 200
+      expect(WorkDay.where(id: work_day.id).count).to eq 0
+    end
+  end
+end

--- a/spec/requests/api/v1/work_days/get_work_day_spec.rb
+++ b/spec/requests/api/v1/work_days/get_work_day_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+describe "GET /api/v1/work_days/:id" do
+  let(:headers) { {ApiController::CLIENT_TOKEN_HEADER => Monolithium.config.client_token} }
+
+  context "with invalid id" do
+    it "returns 404" do
+      get "/api/v1/work_days/invalid", headers: headers
+
+      expect(response.status).to eq 404
+      expect(response.body).to match "Couldn't find WorkDay"
+    end
+  end
+
+  context "with a valid id" do
+    it "returns the json for that record" do
+      work_day = FactoryBot.create(
+        :work_day,
+        adjust_minutes: 0,
+        date: Date.today,
+        in_minutes: 480,
+        out_minutes: 960,
+        pto_minutes: 0
+      )
+
+      get "/api/v1/work_days/#{work_day.id}", headers: headers
+
+      expect(response.status).to eq 200
+      expect(response.parsed_body).to match({
+        "adjust_minutes" => 0,
+        "created_at" => anything,
+        "date" => Date.today.to_s,
+        "id" => work_day.id,
+        "in_minutes" => 480,
+        "out_minutes" => 960,
+        "pto_minutes" => 0,
+        "updated_at" => anything
+      })
+    end
+  end
+
+  context "with random id" do
+    it "returns a random record" do
+      work_day = FactoryBot.create(:work_day)
+      expect(WorkDay).to receive(:random).and_return(work_day)
+
+      get "/api/v1/work_days/random", headers: headers
+
+      expect(response.status).to eq 200
+      expect(response.parsed_body["id"]).to eq(work_day.id)
+    end
+  end
+end

--- a/spec/requests/api/v1/work_days/get_work_days_spec.rb
+++ b/spec/requests/api/v1/work_days/get_work_days_spec.rb
@@ -1,0 +1,104 @@
+require "rails_helper"
+
+describe "GET /api/v1/work_days" do
+  let(:headers) { {ApiController::CLIENT_TOKEN_HEADER => Monolithium.config.client_token} }
+
+  context "without a number param" do
+    let(:params) { {year: 2025} }
+
+    it "returns a 400 and error message" do
+      get "/api/v1/work_days", params: params, headers: headers
+
+      expect(response.status).to eq 400
+      expect(response.parsed_body["error"]).to eq "number is required"
+    end
+  end
+
+  context "without a year param" do
+    let(:params) { {number: 7} }
+
+    it "returns a 400 and error message" do
+      get "/api/v1/work_days", params: params, headers: headers
+
+      expect(response.status).to eq 400
+      expect(response.parsed_body["error"]).to eq "year is required"
+    end
+  end
+
+  context "with no records for the year and number params" do
+    let(:params) { {number: 7, year: 2025} }
+
+    it "returns default records sorted by date" do
+      get "/api/v1/work_days", params: params, headers: headers
+
+      expect(response.status).to eq 200
+
+      actual_data = response.parsed_body.map do |work_day|
+        work_day.values_at(
+          "date",
+          "in_minutes",
+          "out_minutes",
+          "pto_minutes",
+          "adjust_minutes"
+        )
+      end
+
+      expect(actual_data).to eq([
+        ["2025-02-10", nil, nil, nil, nil],
+        ["2025-02-11", nil, nil, nil, nil],
+        ["2025-02-12", nil, nil, nil, nil],
+        ["2025-02-13", nil, nil, nil, nil],
+        ["2025-02-14", nil, nil, nil, nil]
+      ])
+    end
+  end
+
+  context "with records for the year and number params" do
+    let(:params) { {number: 7, year: 2025} }
+
+    it "returns the json for those records" do
+      [
+        ["2025-02-10", 480, 960, 0, 30],
+        ["2025-02-11", 480, 930, 0, 0],
+        ["2025-02-12", 0, 0, 480, 0],
+        ["2025-02-13", 540, 960, 0, 0],
+        ["2025-02-14", 480, 1020, 0, 0]
+      ].each do |work_day|
+        date, in_minutes, out_minutes, pto_minutes, adjust_minutes = work_day
+        created_at = rand(1..5).days.ago
+
+        FactoryBot.create(
+          :work_day,
+          adjust_minutes: adjust_minutes,
+          created_at: created_at,
+          date: date,
+          in_minutes: in_minutes,
+          out_minutes: out_minutes,
+          pto_minutes: pto_minutes
+        )
+      end
+
+      get "/api/v1/work_days", params: params, headers: headers
+
+      expect(response.status).to eq 200
+
+      actual_data = response.parsed_body.map do |work_day|
+        work_day.values_at(
+          "date",
+          "in_minutes",
+          "out_minutes",
+          "pto_minutes",
+          "adjust_minutes"
+        )
+      end
+
+      expect(actual_data).to eq([
+        ["2025-02-10", 480, 960, 0, 30],
+        ["2025-02-11", 480, 930, 0, 0],
+        ["2025-02-12", 0, 0, 480, 0],
+        ["2025-02-13", 540, 960, 0, 0],
+        ["2025-02-14", 480, 1020, 0, 0]
+      ])
+    end
+  end
+end

--- a/spec/requests/api/v1/work_days/update_work_day_spec.rb
+++ b/spec/requests/api/v1/work_days/update_work_day_spec.rb
@@ -1,23 +1,23 @@
 require "rails_helper"
 
-describe "PUT /api/v1/books/:id" do
+describe "PUT /api/v1/work_days/:id" do
   let(:headers) { {ApiController::CLIENT_TOKEN_HEADER => Monolithium.config.client_token} }
 
   context "with an invalid id" do
     it "returns 404 and an error message" do
-      put "/api/v1/books/invalid", headers: headers
+      put "/api/v1/work_days/invalid", headers: headers
 
       expect(response.status).to eq 404
-      expect(response.body).to match "Couldn't find Book"
+      expect(response.body).to match "Couldn't find WorkDay"
     end
   end
 
   context "without required param" do
-    let(:book) { FactoryBot.create(:book) }
+    let(:work_day) { FactoryBot.create(:work_day) }
     let(:params) { {} }
 
     it "returns 400 and an error message" do
-      put "/api/v1/books/#{book.id}", params: params, headers: headers
+      put "/api/v1/work_days/#{work_day.id}", params: params, headers: headers
 
       expect(response.status).to eq 400
       expect(response.body).to match "param is missing"
@@ -25,11 +25,11 @@ describe "PUT /api/v1/books/:id" do
   end
 
   context "with an invalid update" do
-    let(:book) { FactoryBot.create(:book) }
-    let(:params) { {book: {format: "invalid"}} }
+    let(:work_day) { FactoryBot.create(:work_day) }
+    let(:params) { {work_day: {date: "invalid"}} }
 
     it "returns 400 and an error message" do
-      put "/api/v1/books/#{book.id}", params: params, headers: headers
+      put "/api/v1/work_days/#{work_day.id}", params: params, headers: headers
 
       expect(response.status).to eq 400
       expect(response.body).to match "Validation failed"
@@ -37,24 +37,24 @@ describe "PUT /api/v1/books/:id" do
   end
 
   context "with a valid id and update" do
-    let(:book) { FactoryBot.create(:book, title: "Midwest Convos") }
-    let(:params) { {book: {title: "Guide to Midwestern Conversation"}} }
+    let(:work_day) { FactoryBot.create(:work_day, date: Date.today) }
+    let(:params) { {work_day: {date: Date.yesterday}} }
 
     it "returns 200 and the updated json" do
-      put "/api/v1/books/#{book.id}", params: params, headers: headers
+      put "/api/v1/work_days/#{work_day.id}", params: params, headers: headers
 
       expect(response.status).to eq 200
-      expect(response.parsed_body["title"]).to eq "Guide to Midwestern Conversation"
+      expect(response.parsed_body["date"]).to eq Date.yesterday.to_s
     end
   end
 
   context "with bonus attribute" do
-    let(:book) { FactoryBot.create(:book) }
+    let(:work_day) { FactoryBot.create(:work_day) }
     let(:zero_time) { Time.at(0).utc }
-    let(:params) { {book: {created_at: zero_time}} }
+    let(:params) { {work_day: {created_at: zero_time}} }
 
     it "ignores bonus attributes" do
-      put "/api/v1/books/#{book.id}", params: params, headers: headers
+      put "/api/v1/work_days/#{work_day.id}", params: params, headers: headers
 
       expect(response.status).to eq 200
       expect(response.parsed_body["created_at"]).to_not eq zero_time.as_json


### PR DESCRIPTION
This PR adds another set of REST endpoints to the API this time for the `WorkDay` model. I mostly just copy/pasted from the code for the `Book` endpoints so I think I'm getting to the point where I can extract some patterns and build a generator for this - that should be next.