### PR TITLE
Extract permitted params model methods

### DIFF
--- a/app/controllers/api/v1/books_controller.rb
+++ b/app/controllers/api/v1/books_controller.rb
@@ -26,7 +26,7 @@ module Api
       private
 
       def book_params
-        params.require(:book).permit(:finished_on, :format, :isbn, :pages, :title)
+        params.require(:book).permit(Book.permitted_params)
       end
     end
   end

--- a/app/controllers/api/v1/work_days_controller.rb
+++ b/app/controllers/api/v1/work_days_controller.rb
@@ -28,13 +28,7 @@ module Api
       private
 
       def work_day_params
-        params.require(:work_day).permit(
-          :adjust_minutes,
-          :date,
-          :in_minutes,
-          :out_minutes,
-          :pto_minutes
-        )
+        params.require(:work_day).permit(WorkDay.permitted_params)
       end
 
       def ensure_work_week_params

--- a/app/controllers/crud/books_controller.rb
+++ b/app/controllers/crud/books_controller.rb
@@ -38,6 +38,6 @@ class Crud::BooksController < ApplicationController
   private
 
   def book_params
-    params.require(:book).permit(:finished_on, :format, :isbn, :pages, :title)
+    params.require(:book).permit(Book.permitted_params)
   end
 end

--- a/app/controllers/crud/csv_uploads_controller.rb
+++ b/app/controllers/crud/csv_uploads_controller.rb
@@ -38,7 +38,7 @@ class Crud::CsvUploadsController < ApplicationController
   private
 
   def csv_upload_params
-    safe_params = params.require(:csv_upload).permit(:original_filename, :parser_class_name)
+    safe_params = params.require(:csv_upload).permit(CsvUpload.permitted_params)
 
     if params[:file]
       safe_params[:original_filename] = params[:file].original_filename

--- a/app/controllers/crud/financial_accounts_controller.rb
+++ b/app/controllers/crud/financial_accounts_controller.rb
@@ -37,6 +37,6 @@ class Crud::FinancialAccountsController < ApplicationController
   private
 
   def financial_account_params
-    params.require(:financial_account).permit(:category, :name)
+    params.require(:financial_account).permit(FinancialAccount.permitted_params)
   end
 end

--- a/app/controllers/crud/financial_statements_controller.rb
+++ b/app/controllers/crud/financial_statements_controller.rb
@@ -46,7 +46,7 @@ class Crud::FinancialStatementsController < ApplicationController
   private
 
   def financial_statement_params
-    params.require(:financial_statement).permit(:ending_amount_cents, :period_start_on, :starting_amount_cents)
+    params.require(:financial_statement).permit(FinancialStatement.permitted_params)
   end
 
   def random_financial_statement

--- a/app/controllers/crud/gift_ideas_controller.rb
+++ b/app/controllers/crud/gift_ideas_controller.rb
@@ -37,6 +37,6 @@ class Crud::GiftIdeasController < ApplicationController
   private
 
   def gift_idea_params
-    params.require(:gift_idea).permit(:title, :website_url, :note)
+    params.require(:gift_idea).permit(GiftIdea.permitted_params)
   end
 end

--- a/app/controllers/crud/post_bin_requests_controller.rb
+++ b/app/controllers/crud/post_bin_requests_controller.rb
@@ -37,6 +37,6 @@ class Crud::PostBinRequestsController < ApplicationController
   private
 
   def post_bin_request_params
-    params.require(:post_bin_request).permit(:body, :headers, :params)
+    params.require(:post_bin_request).permit(PostBinRequest.permitted_params)
   end
 end

--- a/app/controllers/crud/projects_controller.rb
+++ b/app/controllers/crud/projects_controller.rb
@@ -37,6 +37,6 @@ class Crud::ProjectsController < ApplicationController
   private
 
   def project_params
-    params.require(:project).permit(:name, :touched_at)
+    params.require(:project).permit(Project.permitted_params)
   end
 end

--- a/app/controllers/crud/raw_hooks_controller.rb
+++ b/app/controllers/crud/raw_hooks_controller.rb
@@ -37,6 +37,6 @@ class Crud::RawHooksController < ApplicationController
   private
 
   def raw_hook_params
-    params.require(:raw_hook).permit(:body, :headers, :params)
+    params.require(:raw_hook).permit(RawHook.permitted_params)
   end
 end

--- a/app/controllers/crud/sneakers_controller.rb
+++ b/app/controllers/crud/sneakers_controller.rb
@@ -37,6 +37,6 @@ class Crud::SneakersController < ApplicationController
   private
 
   def sneaker_params
-    params.require(:sneaker).permit(:amount_cents, :details, :image, :name, :ordered_on)
+    params.require(:sneaker).permit(Sneaker.permitted_params)
   end
 end

--- a/app/controllers/crud/warm_fuzzies_controller.rb
+++ b/app/controllers/crud/warm_fuzzies_controller.rb
@@ -37,6 +37,6 @@ class Crud::WarmFuzziesController < ApplicationController
   private
 
   def warm_fuzzy_params
-    params.require(:warm_fuzzy).permit(:author, :body, :received_at, :screenshot, :title)
+    params.require(:warm_fuzzy).permit(WarmFuzzy.permitted_params)
   end
 end

--- a/app/controllers/crud/webhook_senders_controller.rb
+++ b/app/controllers/crud/webhook_senders_controller.rb
@@ -37,6 +37,6 @@ class Crud::WebhookSendersController < ApplicationController
   private
 
   def webhook_sender_params
-    params.require(:webhook_sender).permit(:name, :parser)
+    params.require(:webhook_sender).permit(WebhookSender.permitted_params)
   end
 end

--- a/app/models/book.rb
+++ b/app/models/book.rb
@@ -7,6 +7,16 @@ class Book < ApplicationRecord
 
   has_object :enhancer
 
+  def self.permitted_params
+    [
+      :finished_on,
+      :format,
+      :isbn,
+      :pages,
+      :title
+    ]
+  end
+
   def table_attrs
     [
       ["ISBN", isbn],

--- a/app/models/csv_upload.rb
+++ b/app/models/csv_upload.rb
@@ -3,6 +3,13 @@ require "csv"
 class CsvUpload < ApplicationRecord
   validates_presence_of :data, :original_filename, :parser_class_name
 
+  def self.permitted_params
+    [
+      :original_filename,
+      :parser_class_name
+    ]
+  end
+
   def parsed_data
     CSV.parse(data)
   rescue CSV::MalformedCSVError

--- a/app/models/financial_account.rb
+++ b/app/models/financial_account.rb
@@ -15,6 +15,13 @@ class FinancialAccount < ApplicationRecord
   validates_uniqueness_of :name
   validates_inclusion_of :category, in: CATEGORIES
 
+  def self.permitted_params
+    [
+      :category,
+      :name
+    ]
+  end
+
   def table_attrs
     [
       ["Name", name],

--- a/app/models/financial_statement.rb
+++ b/app/models/financial_statement.rb
@@ -6,6 +6,14 @@ class FinancialStatement < ApplicationRecord
 
   scope :for_year, ->(year) { where("extract(year from period_start_on) = ?", year) }
 
+  def self.permitted_params
+    [
+      :ending_amount_cents,
+      :period_start_on,
+      :starting_amount_cents
+    ]
+  end
+
   def net_amount_cents
     ending_amount_cents - starting_amount_cents
   end

--- a/app/models/gift_idea.rb
+++ b/app/models/gift_idea.rb
@@ -6,6 +6,14 @@ class GiftIdea < ApplicationRecord
   scope :received, -> { where("received_at IS NOT NULL") }
   scope :not_received, -> { where("received_at IS NULL") }
 
+  def self.permitted_params
+    [
+      :note,
+      :title,
+      :website_url
+    ]
+  end
+
   def table_attrs
     [
       ["Title", title],

--- a/app/models/post_bin_request.rb
+++ b/app/models/post_bin_request.rb
@@ -3,6 +3,14 @@ class PostBinRequest < ApplicationRecord
 
   after_create_commit :created
 
+  def self.permitted_params
+    [
+      :body,
+      :headers,
+      :params
+    ]
+  end
+
   def table_attrs
     [
       ["Created At", created_at.to_fs],

--- a/app/models/project.rb
+++ b/app/models/project.rb
@@ -1,6 +1,13 @@
 class Project < ApplicationRecord
   validates :name, presence: true, uniqueness: true
 
+  def self.permitted_params
+    [
+      :name,
+      :touched_at
+    ]
+  end
+
   def table_attrs
     [
       ["Name", name],

--- a/app/models/raw_hook.rb
+++ b/app/models/raw_hook.rb
@@ -5,6 +5,14 @@ class RawHook < ApplicationRecord
 
   after_create_commit :created
 
+  def self.permitted_params
+    [
+      :body,
+      :headers,
+      :params
+    ]
+  end
+
   def table_attrs
     [
       ["Created At", created_at.to_fs],

--- a/app/models/sneaker.rb
+++ b/app/models/sneaker.rb
@@ -6,6 +6,16 @@ class Sneaker < ApplicationRecord
 
   has_one_attached :image
 
+  def self.permitted_params
+    [
+      :amount_cents,
+      :details,
+      :image,
+      :name,
+      :ordered_on
+    ]
+  end
+
   def table_attrs
     [
       ["Name", name],

--- a/app/models/warm_fuzzy.rb
+++ b/app/models/warm_fuzzy.rb
@@ -5,6 +5,16 @@ class WarmFuzzy < ApplicationRecord
   validates :received_at, presence: true
   validates :title, presence: true
 
+  def self.permitted_params
+    [
+      :author,
+      :body,
+      :received_at,
+      :screenshot,
+      :title
+    ]
+  end
+
   def table_attrs
     [
       ["Title", title],

--- a/app/models/webhook_sender.rb
+++ b/app/models/webhook_sender.rb
@@ -3,6 +3,13 @@ class WebhookSender < ApplicationRecord
   validates :name, presence: true
   validates :parser, presence: true
 
+  def self.permitted_params
+    [
+      :name,
+      :parser
+    ]
+  end
+
   def self.circle
     find_by(name: "Circle CI")
   end

--- a/app/models/work_day.rb
+++ b/app/models/work_day.rb
@@ -1,6 +1,16 @@
 class WorkDay < ApplicationRecord
   validates :date, presence: true
 
+  def self.permitted_params
+    [
+      :adjust_minutes,
+      :date,
+      :in_minutes,
+      :out_minutes,
+      :pto_minutes
+    ]
+  end
+
   def day_of_week
     date.strftime("%A")
   end


### PR DESCRIPTION
This PR formalizes a pattern I noticed where the list of permitted params in the API and CRUD controllers tends to match for a given model. So what I did was extract a class method to the models in question and then updated the controllers to use the method. For some of these models there was not exactly duplication just yet but I think it's a worthwhile pattern even if the current usage does not have duplication.