### PR TITLE
Add vanishing box api endpoint

### DIFF
--- a/app/controllers/api/v1/vanishing_messages_controller.rb
+++ b/app/controllers/api/v1/vanishing_messages_controller.rb
@@ -4,11 +4,7 @@ module Api
       def create
         head :bad_request and return unless params[:body].present?
 
-        payload = {
-          body: params[:body],
-          created_at: Time.now.to_fs
-        }
-        VanishingBoxChannel.broadcast(payload)
+        VanishingMessage.fire_and_forget(params[:body])
         head :created
       end
     end

--- a/app/controllers/api/v1/vanishing_messages_controller.rb
+++ b/app/controllers/api/v1/vanishing_messages_controller.rb
@@ -1,0 +1,16 @@
+module Api
+  module V1
+    class VanishingMessagesController < Api::V1Controller
+      def create
+        head :bad_request and return unless params[:body].present?
+
+        payload = {
+          body: params[:body],
+          created_at: Time.now.to_fs
+        }
+        VanishingBoxChannel.broadcast(payload)
+        head :created
+      end
+    end
+  end
+end

--- a/app/controllers/vanishing_box_controller.rb
+++ b/app/controllers/vanishing_box_controller.rb
@@ -1,10 +1,7 @@
 class VanishingBoxController < ApplicationController
   def create
-    payload = {
-      body: params[:body],
-      created_at: Time.now.to_fs
-    }
-    VanishingBoxChannel.broadcast(payload)
+    VanishingMessage.fire_and_forget(params[:body])
+
     head :created
   end
 end

--- a/app/models/vanishing_message.rb
+++ b/app/models/vanishing_message.rb
@@ -1,0 +1,22 @@
+class VanishingMessage
+  def self.fire_and_forget(body)
+    vanishing_message = new(body)
+    vanishing_message.broadcast
+    nil
+  end
+
+  def initialize(body)
+    @body = body
+    @created_at = Time.now
+  end
+
+  def broadcast
+    VanishingBoxChannel.broadcast(as_payload)
+  end
+
+  private
+
+  def as_payload
+    {body: @body, created_at: @created_at.to_fs}
+  end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -63,6 +63,7 @@ Rails.application.routes.draw do
       get :ping, to: "ping#show"
       post :post_bin, to: "post_bin#create"
       post :raw_hooks, to: "raw_hooks#create"
+      post :vanishing_messages, to: "vanishing_messages#create"
 
       namespace :word_rot do
         get :killswitch, to: "killswitch#show"

--- a/spec/requests/api/v1/vanishing_messages_spec.rb
+++ b/spec/requests/api/v1/vanishing_messages_spec.rb
@@ -1,0 +1,25 @@
+require "rails_helper"
+
+describe "POST /api/v1/vanishing_messages" do
+  let(:headers) { {ApiController::CLIENT_TOKEN_HEADER => Monolithium.config.client_token} }
+
+  context "without required param" do
+    let(:params) { {} }
+
+    it "returns 400" do
+      post "/api/v1/vanishing_messages", params: params, headers: headers
+      expect(response.status).to eq 400
+    end
+  end
+
+  context "with valid required param" do
+    let(:params) { {body: "top secret message!"} }
+
+    it "returns 201 and sends the broadcast" do
+      expected_payload = {body: "top secret message!", created_at: anything}
+      expect(VanishingBoxChannel).to receive(:broadcast).with(expected_payload)
+      post "/api/v1/vanishing_messages", params: params, headers: headers
+      expect(response.status).to eq 201
+    end
+  end
+end


### PR DESCRIPTION
This PR adds a model called `VanishingMessage` and a corresponding API endpoint to "create" one. The model is just a PORO and it exposes a class method called `fire_and_forget` that will create an instance, broadcast the body, and then allow the object to fall out of memory. Now I can add things to the vanishing box programmatically!