### PR TITLE
Add Rails generator for CRUD pages

### DIFF
--- a/.rspec
+++ b/.rspec
@@ -1,2 +1,3 @@
 --color
+--exclude-pattern "spec/fixtures/**/*"
 --order random

--- a/config/application.rb
+++ b/config/application.rb
@@ -26,7 +26,7 @@ module Monolithium
     # Please, add to the `ignore` list any other `lib` subdirectories that do
     # not contain `.rb` files, or that should not be reloaded or eager loaded.
     # Common ones are `templates`, `generators`, or `middleware`, for example.
-    config.autoload_lib(ignore: %w[assets tasks])
+    config.autoload_lib(ignore: %w[assets generators tasks])
 
     # Configuration for the application, engines, and railties goes here.
     #

--- a/lib/generators/crud/pages/USAGE
+++ b/lib/generators/crud/pages/USAGE
@@ -1,0 +1,17 @@
+Description:
+    Make CRUD pages for NAME
+
+Example:
+    bin/rails generate crud:pages Thing
+
+    This will create:
+        app/controllers/crud/things_controller.rb
+        app/views/crud/things/_form.html.haml
+        app/views/crud/things/edit.html.haml
+        app/views/crud/things/index.html.haml
+        app/views/crud/things/new.html.haml
+        app/views/crud/things/show.html.haml
+        spec/system/crud/things/admin_creates_thing_spec.rb
+        spec/system/crud/things/admin_edits_thing_spec.rb
+        spec/system/crud/things/admin_views_thing_spec.rb
+        spec/system/crud/things/admin_views_things_spec.rb

--- a/lib/generators/crud/pages/pages_generator.rb
+++ b/lib/generators/crud/pages/pages_generator.rb
@@ -1,0 +1,41 @@
+class Crud::PagesGenerator < Rails::Generators::NamedBase
+  include Rails::Generators::ResourceHelpers
+
+  source_root File.expand_path("templates", __dir__)
+
+  def create_controller
+    controller_folder = "app/controllers/crud"
+    template "controller.erb", "#{controller_folder}/#{plural_name}_controller.rb"
+  end
+
+  def add_routes
+    route "resources :#{plural_name}", namespace: :crud
+  end
+
+  def create_views
+    view_folder = "app/views/crud/#{plural_name}"
+
+    template "views/_form.erb", "#{view_folder}/_form.html.haml"
+    template "views/edit.erb", "#{view_folder}/edit.html.haml"
+    template "views/index.erb", "#{view_folder}/index.html.haml"
+    template "views/new.erb", "#{view_folder}/new.html.haml"
+    template "views/show.erb", "#{view_folder}/show.html.haml"
+  end
+
+  def create_specs
+    spec_folder = "spec/system/crud/#{plural_name}"
+
+    template "specs/admin_creates.erb", "#{spec_folder}/admin_creates_#{singular_name}_spec.rb"
+    template "specs/admin_edits.erb", "#{spec_folder}/admin_edits_#{singular_name}_spec.rb"
+    template "specs/admin_views_list.erb", "#{spec_folder}/admin_views_#{plural_name}_spec.rb"
+    template "specs/admin_views_one.erb", "#{spec_folder}/admin_views_#{singular_name}_spec.rb"
+  end
+
+  def update_dashboard
+    dashboard_view = "app/views/dashboard/show.html.haml"
+    crud_link = "%p= link_to \"#{human_name.pluralize.titleize}\", crud_#{plural_name}_path\n"
+    crud_heading = "%h2 CRUD Pages\n\n"
+
+    insert_into_file dashboard_view, crud_link, after: crud_heading
+  end
+end

--- a/lib/generators/crud/pages/templates/controller.erb
+++ b/lib/generators/crud/pages/templates/controller.erb
@@ -1,0 +1,42 @@
+class Crud::<%= controller_class_name %>Controller < ApplicationController
+  expose(:<%= singular_name %>)
+  expose(:<%= plural_name %>) do
+    <%= class_name %>.order(created_at: :desc).page(params[:page])
+  end
+
+  def show
+    redirect_to crud_<%= singular_name %>_path(<%= class_name %>.random) if random_id?
+  end
+
+  def create
+    if <%= singular_name %>.save
+      flash.notice = "<%= human_name.titleize %> created"
+      redirect_to crud_<%= singular_name %>_path(<%= singular_name %>)
+    else
+      flash.alert = <%= singular_name %>.errors.full_messages.to_sentence
+      redirect_to new_crud_<%= singular_name %>_path
+    end
+  end
+
+  def update
+    if <%= singular_name %>.update(<%= singular_name %>_params)
+      flash.notice = "<%= human_name.titleize %> updated"
+      redirect_to crud_<%= singular_name %>_path(<%= singular_name %>)
+    else
+      flash.alert = <%= singular_name %>.errors.full_messages.to_sentence
+      redirect_to edit_crud_<%= singular_name %>_path(<%= singular_name %>)
+    end
+  end
+
+  def destroy
+    <%= singular_name %>.destroy
+    flash.notice = "<%= human_name.titleize %> deleted"
+    redirect_to crud_<%= plural_name %>_path
+  end
+
+  private
+
+  def <%= singular_name %>_params
+    params.require(:<%= singular_name %>).permit(<%= class_name %>.permitted_params)
+  end
+end

--- a/lib/generators/crud/pages/templates/specs/admin_creates.erb
+++ b/lib/generators/crud/pages/templates/specs/admin_creates.erb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+describe "Admin creates <%= human_name.downcase %>" do
+  include_context "admin password matches"
+
+  scenario "from list page" do
+    visit "/crud/<%= plural_name %>"
+    click_on "New <%= human_name.titleize %>"
+    expect(page).to have_css "h1", text: "New <%= human_name.titleize %>"
+    expect(page).to have_css "a", text: "<%= human_name.titleize %> List"
+    expect(page).to have_current_path new_crud_<%= singular_name%>_path
+  end
+
+  scenario "create with errors" do
+    visit "/crud/<%= plural_name %>/new"
+    click_on "create"
+    expect(page).to have_css ".alert", text: "REPLACE_ME"
+    expect(page).to have_current_path new_crud_<%= singular_name %>_path
+  end
+
+  scenario "create successfully" do
+    visit "/crud/<%= plural_name %>/new"
+    fill_in "REPLACE_ME", with: "REPLACE_ME"
+    click_on "create"
+
+    expect(page).to have_css ".notice", text: "<%= human_name.titleize %> created"
+
+    <%= singular_name %> = <%= class_name %>.last
+    expect(page).to have_current_path crud_<%= singular_name %>_path(<%= singular_name %>)
+
+    actual_values = page.all("tr").map do |table_row|
+      table_row.all("td").map(&:text)
+    end
+
+    expect(actual_values).to eq(
+      [
+        ["REPLACE_ME", "REPLACE_ME"],
+        ["Created At", <%= singular_name %>.created_at.to_fs],
+        ["Updated At", <%= singular_name %>.updated_at.to_fs]
+      ]
+    )
+  end
+end

--- a/lib/generators/crud/pages/templates/specs/admin_edits.erb
+++ b/lib/generators/crud/pages/templates/specs/admin_edits.erb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe "Admin edits <%= human_name.downcase %>" do
+  include_context "admin password matches"
+
+  scenario "from show page" do
+    <%= singular_name %> = FactoryBot.create(:<%= singular_name %>)
+    visit "/crud/<%= plural_name %>/#{<%= singular_name %>.id}"
+    click_on "Edit <%= human_name.titleize %>"
+    expect(page).to have_css "h1", text: "Edit <%= human_name.titleize %> #{<%= singular_name %>.id}"
+    expect(page).to have_css "a", text: "Show <%= human_name.titleize %>"
+    expect(page).to have_current_path edit_crud_<%= singular_name %>_path(<%= singular_name %>)
+  end
+
+  scenario "edit with errors" do
+    <%= singular_name %> = FactoryBot.create(:<%= singular_name %>)
+    visit "/crud/<%= plural_name %>/#{<%= singular_name %>.id}/edit"
+    fill_in "REPLACE_ME", with: ""
+    click_on "update"
+    expect(page).to have_css ".alert", text: "REPLACE_ME"
+  end
+
+  scenario "edit successfully" do
+    <%= singular_name %> = FactoryBot.create(
+      :<%= singular_name %>,
+      REPLACE_ME: "REPLACE_ME"
+    )
+    visit "/crud/<%= plural_name %>/#{<%= singular_name %>.id}/edit"
+    fill_in "REPLACE_ME", with: "REPLACE_ME"
+    click_on "update"
+
+    expect(page).to have_css ".notice", text: "<%= human_name.titleize %> updated"
+    expect(page).to have_current_path crud_<%= singular_name %>_path(<%= singular_name %>)
+    expect(page).to have_css "td", text: "REPLACE_ME"
+  end
+end

--- a/lib/generators/crud/pages/templates/specs/admin_views_list.erb
+++ b/lib/generators/crud/pages/templates/specs/admin_views_list.erb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe "Admin views <%= human_name.pluralize.downcase %>" do
+  include_context "admin password matches"
+
+  scenario "from dashboard" do
+    visit "/dashboard"
+    click_on "<%= human_name.pluralize.titleize %>"
+    expect(page).to have_css "h1", text: "<%= human_name.pluralize.titleize %>"
+    expect(page).to have_current_path crud_<%= plural_name %>_path
+  end
+
+  scenario "with no records" do
+    visit "/crud/<%= plural_name %>"
+    expect(page.all("tbody tr").count).to eq 0
+  end
+
+  scenario "with a page of records" do
+    FactoryBot.create_list(:<%= singular_name %>, 3)
+    visit "/crud/<%= plural_name %>"
+    expect(page.all("tbody tr").count).to eq 3
+    expect(page).to_not have_css "nav.pagination"
+  end
+
+  scenario "with two pages of records" do
+    FactoryBot.create_list(:<%= singular_name %>, 4)
+    visit "/crud/<%= plural_name %>"
+    expect(page.all("tbody tr").count).to eq 3
+    expect(page).to have_css "nav.pagination"
+  end
+end

--- a/lib/generators/crud/pages/templates/specs/admin_views_one.erb
+++ b/lib/generators/crud/pages/templates/specs/admin_views_one.erb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe "Admin views <%= human_name.downcase %>" do
+  include_context "admin password matches"
+
+  scenario "from list page" do
+    <%= singular_name %> = FactoryBot.create(:<%= singular_name %>)
+    visit "/crud/<%= plural_name %>"
+    click_on <%= singular_name %>.id.to_s
+    expect(page).to have_css "h1", text: "<%= human_name.titleize %> #{<%= singular_name %>.id}"
+    expect(page).to have_css "a", text: "<%= human_name.titleize %> List"
+    expect(page).to have_current_path crud_<%= singular_name %>_path(<%= singular_name %>)
+  end
+
+  scenario "viewing a record" do
+    <%= singular_name %> = FactoryBot.create(
+      :<%= singular_name %>,
+      REPLACE_ME: "REPLACE_ME"
+    )
+
+    visit "/crud/<%= plural_name %>/#{<%= singular_name %>.id}"
+
+    actual_values = page.all("tr").map do |table_row|
+      table_row.all("td").map(&:text)
+    end
+
+    expect(actual_values).to eq(
+      [
+        ["REPLACE_ME", "REPLACE_ME"],
+        ["Created At", <%= singular_name %>.created_at.to_fs],
+        ["Updated At", <%= singular_name %>.updated_at.to_fs]
+      ]
+    )
+  end
+
+  scenario "views random record" do
+    <%= singular_name %> = FactoryBot.create(:<%= singular_name %>)
+    expect(<%= class_name %>).to receive(:random).and_return(<%= singular_name %>)
+
+    visit "/crud/<%= plural_name %>"
+    click_on "Random <%= human_name.titleize %>"
+
+    expect(page).to have_css "h1", text: "<%= human_name.titleize %> #{<%= singular_name %>.id}"
+    expect(page).to have_current_path crud_<%= singular_name %>_path(<%= singular_name %>)
+  end
+end

--- a/lib/generators/crud/pages/templates/views/_form.erb
+++ b/lib/generators/crud/pages/templates/views/_form.erb
@@ -1,0 +1,8 @@
+= form_with model: [:crud, <%= singular_name %>] do |form|
+  = form.date_field :REPLACE_ME, placeholder: "REPLACE_ME"
+  = form.datetime_local_field :REPLACE_ME, placeholder: "REPLACE_ME"
+  = form.file_field :REPLACE_ME, placeholder: "REPLACE_ME"
+  = form.select :REPLACE_ME, REPLACE_ME, selected: REPLACE_ME
+  = form.text_area :REPLACE_ME, placeholder: "REPLACE_ME"
+  = form.text_field :REPLACE_ME, placeholder: "REPLACE_ME"
+  = form.button button_label

--- a/lib/generators/crud/pages/templates/views/edit.erb
+++ b/lib/generators/crud/pages/templates/views/edit.erb
@@ -1,0 +1,5 @@
+%h1 Edit <%= human_name.titleize %> #{<%= singular_name %>.id}
+
+%p= link_to "Show <%= human_name.titleize %>", crud_<%= singular_name %>_path(<%= singular_name %>)
+
+= render "form", <%= singular_name %>: <%= singular_name %>, button_label: "update"

--- a/lib/generators/crud/pages/templates/views/index.erb
+++ b/lib/generators/crud/pages/templates/views/index.erb
@@ -1,0 +1,18 @@
+%h1 <%= human_name.pluralize.titleize %>
+
+%p= link_to "New <%= human_name.titleize %>", new_crud_<%= singular_name %>_path
+
+%p= link_to "Random <%= human_name.titleize %>", crud_<%= singular_name %>_path("random")
+
+%table
+  %thead
+    %tr
+      %th ID
+      %th.text-right Created At
+  %tbody
+    - <%= plural_name %>.each do |<%= singular_name %>|
+      %tr
+        %td= link_to <%= singular_name %>.id, crud_<%= singular_name %>_path(<%= singular_name %>)
+        %td.text-right= <%= singular_name %>.created_at.to_fs
+
+= paginate <%= plural_name %>

--- a/lib/generators/crud/pages/templates/views/new.erb
+++ b/lib/generators/crud/pages/templates/views/new.erb
@@ -1,0 +1,5 @@
+%h1 New <%= human_name.titleize %>
+
+%p= link_to "<%= human_name.titleize %> List", crud_<%= plural_name %>_path
+
+= render "form", <%= singular_name %>: <%= singular_name %>, button_label: "create"

--- a/lib/generators/crud/pages/templates/views/show.erb
+++ b/lib/generators/crud/pages/templates/views/show.erb
@@ -1,0 +1,9 @@
+%h1 <%= human_name.titleize %> #{<%= singular_name %>.id}
+
+%p= link_to "<%= human_name.titleize %> List", crud_<%= plural_name %>_path
+
+%p= link_to "Edit <%= human_name.titleize %>", edit_crud_<%= singular_name %>_path(<%= singular_name %>)
+
+%p= link_to "Delete <%= human_name.titleize %>", crud_<%= singular_name %>_path(<%= singular_name %>), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }
+
+= render partial: "attrs_table", locals: { attrs: <%= singular_name %>.table_attrs }

--- a/spec/fixtures/generators/crud_pages/app/controllers/crud/things_controller.rb
+++ b/spec/fixtures/generators/crud_pages/app/controllers/crud/things_controller.rb
@@ -1,0 +1,42 @@
+class Crud::ThingsController < ApplicationController
+  expose(:thing)
+  expose(:things) do
+    Thing.order(created_at: :desc).page(params[:page])
+  end
+
+  def show
+    redirect_to crud_thing_path(Thing.random) if random_id?
+  end
+
+  def create
+    if thing.save
+      flash.notice = "Thing created"
+      redirect_to crud_thing_path(thing)
+    else
+      flash.alert = thing.errors.full_messages.to_sentence
+      redirect_to new_crud_thing_path
+    end
+  end
+
+  def update
+    if thing.update(thing_params)
+      flash.notice = "Thing updated"
+      redirect_to crud_thing_path(thing)
+    else
+      flash.alert = thing.errors.full_messages.to_sentence
+      redirect_to edit_crud_thing_path(thing)
+    end
+  end
+
+  def destroy
+    thing.destroy
+    flash.notice = "Thing deleted"
+    redirect_to crud_things_path
+  end
+
+  private
+
+  def thing_params
+    params.require(:thing).permit(Thing.permitted_params)
+  end
+end

--- a/spec/fixtures/generators/crud_pages/app/views/crud/things/_form.html.haml
+++ b/spec/fixtures/generators/crud_pages/app/views/crud/things/_form.html.haml
@@ -1,0 +1,8 @@
+= form_with model: [:crud, thing] do |form|
+  = form.date_field :REPLACE_ME, placeholder: "REPLACE_ME"
+  = form.datetime_local_field :REPLACE_ME, placeholder: "REPLACE_ME"
+  = form.file_field :REPLACE_ME, placeholder: "REPLACE_ME"
+  = form.select :REPLACE_ME, REPLACE_ME, selected: REPLACE_ME
+  = form.text_area :REPLACE_ME, placeholder: "REPLACE_ME"
+  = form.text_field :REPLACE_ME, placeholder: "REPLACE_ME"
+  = form.button button_label

--- a/spec/fixtures/generators/crud_pages/app/views/crud/things/edit.html.haml
+++ b/spec/fixtures/generators/crud_pages/app/views/crud/things/edit.html.haml
@@ -1,0 +1,5 @@
+%h1 Edit Thing #{thing.id}
+
+%p= link_to "Show Thing", crud_thing_path(thing)
+
+= render "form", thing: thing, button_label: "update"

--- a/spec/fixtures/generators/crud_pages/app/views/crud/things/index.html.haml
+++ b/spec/fixtures/generators/crud_pages/app/views/crud/things/index.html.haml
@@ -1,0 +1,18 @@
+%h1 Things
+
+%p= link_to "New Thing", new_crud_thing_path
+
+%p= link_to "Random Thing", crud_thing_path("random")
+
+%table
+  %thead
+    %tr
+      %th ID
+      %th.text-right Created At
+  %tbody
+    - things.each do |thing|
+      %tr
+        %td= link_to thing.id, crud_thing_path(thing)
+        %td.text-right= thing.created_at.to_fs
+
+= paginate things

--- a/spec/fixtures/generators/crud_pages/app/views/crud/things/new.html.haml
+++ b/spec/fixtures/generators/crud_pages/app/views/crud/things/new.html.haml
@@ -1,0 +1,5 @@
+%h1 New Thing
+
+%p= link_to "Thing List", crud_things_path
+
+= render "form", thing: thing, button_label: "create"

--- a/spec/fixtures/generators/crud_pages/app/views/crud/things/show.html.haml
+++ b/spec/fixtures/generators/crud_pages/app/views/crud/things/show.html.haml
@@ -1,0 +1,9 @@
+%h1 Thing #{thing.id}
+
+%p= link_to "Thing List", crud_things_path
+
+%p= link_to "Edit Thing", edit_crud_thing_path(thing)
+
+%p= link_to "Delete Thing", crud_thing_path(thing), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }
+
+= render partial: "attrs_table", locals: { attrs: thing.table_attrs }

--- a/spec/fixtures/generators/crud_pages/app/views/dashboard/show.html.haml
+++ b/spec/fixtures/generators/crud_pages/app/views/dashboard/show.html.haml
@@ -1,0 +1,42 @@
+%h1 Dashboard
+
+%h2 Public Pages
+
+%p= link_to "Artsy Viewer", artsy_viewer_path
+%p= link_to "Decode JWT", decode_jwt_path
+%p= link_to "Fairing Direball", faring_direball_path
+%p= link_to "Reading List", reading_list_path(year: Time.now.year)
+%p= link_to "Root", root_path
+%p= link_to "Sneakers Page", sneakers_path
+%p= link_to "Style Pages", article_styles_path
+%p= link_to "Wishlist", wishlist_path
+
+%h2 Private Pages
+
+%p= link_to "Cybertail", cybertail_path
+%p= link_to "Financial Report", financial_report_path(year: Time.now.year)
+%p= link_to "Fuzzies", fuzzies_path
+%p= link_to "Live Post Bin", post_bin_path
+%p= link_to "Model Counts", model_counts_path
+%p= link_to "Project List", project_list_path
+%p= link_to "Today", today_path
+%p= link_to "Vanishing Box", vanishing_box_path
+
+%h2 CRUD Pages
+
+%p= link_to "Things", crud_things_path
+%p= link_to "Books", crud_books_path
+%p= link_to "CSV Uploads", crud_csv_uploads_path
+%p= link_to "Financial Accounts", crud_financial_accounts_path
+%p= link_to "Gift Ideas", crud_gift_ideas_path
+%p= link_to "Post Bin Requests", crud_post_bin_requests_path
+%p= link_to "Projects", crud_projects_path
+%p= link_to "Raw Hooks", crud_raw_hooks_path
+%p= link_to "Sneakers", crud_sneakers_path
+%p= link_to "Warm Fuzzies", crud_warm_fuzzies_path
+%p= link_to "Webhook Senders", crud_webhook_senders_path
+
+%h2 Api Routes
+
+%p= link_to "Ping", api_v1_ping_path
+%p= link_to "Word Rot Killswitch", api_v1_word_rot_killswitch_path

--- a/spec/fixtures/generators/crud_pages/config/routes.rb
+++ b/spec/fixtures/generators/crud_pages/config/routes.rb
@@ -1,0 +1,76 @@
+Rails.application.routes.draw do
+  get "artsy-viewer", to: "artsy_viewer#show"
+  get "crank-champ/leaderboard", to: "crank_champ/leaderboard#index"
+  get "cybertail", to: "cybertail#index"
+  get "dashboard", to: "dashboard#show"
+  get "decode-jwt", to: "decode_jwt#show"
+  get "faring_direball", to: "faring_direball#index"
+  get "financial_reports/:year", to: "financial_reports#show", as: :financial_report
+  get "fuzzies", to: "fuzzies#index", as: :fuzzies
+  get "model_counts", to: "model_counts#index", as: :model_counts
+  get "post_bin", to: "post_bin#index"
+  get "reading-list/:year", to: "reading_list#index", as: :reading_list
+  get "sneakers", to: "sneakers#index", as: :sneakers
+  get "today", to: "today#show", as: :today
+  get "wishlist", to: "wishlist#index"
+  get "work_weeks/:target", to: "work_weeks#show", as: :work_week
+
+  get "project_list", to: "project_list#index", as: :project_list
+  patch "project_list/:id", to: "project_list#update"
+
+  get "vanishing-box", to: "vanishing_box#show"
+  post "vanishing-box", to: "vanishing_box#create"
+
+  scope :style do
+    get :article, to: "static#article", as: "article_styles"
+    get :color, to: "static#color", as: "color_styles"
+    get :flashes, to: "static#flashes", as: "flashes_styles"
+    get :form, to: "static#form", as: "form_styles"
+    get :table, to: "static#table", as: "table_styles"
+  end
+
+  get "sign_in", to: "password#new", as: :sign_in
+  post "sign_in", to: "password#create"
+  get "sign_out", to: "password#clear", as: :sign_out
+
+  resources :gift_ideas, only: %i[update]
+
+  resources :crank_users, only: %i[create new show], param: :code do
+    resources :crank_counts, only: %i[create new show]
+  end
+
+  namespace :crud do
+    resources :things
+    resources :books
+    resources :csv_uploads
+    resources :financial_accounts do
+      resources :financial_statements
+    end
+    resources :gift_ideas
+    resources :post_bin_requests
+    resources :projects
+    resources :raw_hooks
+    resources :sneakers
+    resources :warm_fuzzies
+    resources :webhook_senders
+  end
+
+  namespace :api, defaults: {format: :json} do
+    namespace :v1 do
+      resources :books, only: %i[index show create update destroy]
+      resources :work_days, only: %i[index show create update destroy]
+
+      get :decode_jwt, to: "decode_jwt#show"
+      get :ping, to: "ping#show"
+      post :post_bin, to: "post_bin#create"
+      post :raw_hooks, to: "raw_hooks#create"
+      post :vanishing_messages, to: "vanishing_messages#create"
+
+      namespace :word_rot do
+        get :killswitch, to: "killswitch#show"
+      end
+    end
+  end
+
+  root to: "static#root"
+end

--- a/spec/fixtures/generators/crud_pages/spec/system/crud/things/admin_creates_thing_spec.rb
+++ b/spec/fixtures/generators/crud_pages/spec/system/crud/things/admin_creates_thing_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+describe "Admin creates thing" do
+  include_context "admin password matches"
+
+  scenario "from list page" do
+    visit "/crud/things"
+    click_on "New Thing"
+    expect(page).to have_css "h1", text: "New Thing"
+    expect(page).to have_css "a", text: "Thing List"
+    expect(page).to have_current_path new_crud_thing_path
+  end
+
+  scenario "create with errors" do
+    visit "/crud/things/new"
+    click_on "create"
+    expect(page).to have_css ".alert", text: "REPLACE_ME"
+    expect(page).to have_current_path new_crud_thing_path
+  end
+
+  scenario "create successfully" do
+    visit "/crud/things/new"
+    fill_in "REPLACE_ME", with: "REPLACE_ME"
+    click_on "create"
+
+    expect(page).to have_css ".notice", text: "Thing created"
+
+    thing = Thing.last
+    expect(page).to have_current_path crud_thing_path(thing)
+
+    actual_values = page.all("tr").map do |table_row|
+      table_row.all("td").map(&:text)
+    end
+
+    expect(actual_values).to eq(
+      [
+        ["REPLACE_ME", "REPLACE_ME"],
+        ["Created At", thing.created_at.to_fs],
+        ["Updated At", thing.updated_at.to_fs]
+      ]
+    )
+  end
+end

--- a/spec/fixtures/generators/crud_pages/spec/system/crud/things/admin_edits_thing_spec.rb
+++ b/spec/fixtures/generators/crud_pages/spec/system/crud/things/admin_edits_thing_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe "Admin edits thing" do
+  include_context "admin password matches"
+
+  scenario "from show page" do
+    thing = FactoryBot.create(:thing)
+    visit "/crud/things/#{thing.id}"
+    click_on "Edit Thing"
+    expect(page).to have_css "h1", text: "Edit Thing #{thing.id}"
+    expect(page).to have_css "a", text: "Show Thing"
+    expect(page).to have_current_path edit_crud_thing_path(thing)
+  end
+
+  scenario "edit with errors" do
+    thing = FactoryBot.create(:thing)
+    visit "/crud/things/#{thing.id}/edit"
+    fill_in "REPLACE_ME", with: ""
+    click_on "update"
+    expect(page).to have_css ".alert", text: "REPLACE_ME"
+  end
+
+  scenario "edit successfully" do
+    thing = FactoryBot.create(
+      :thing,
+      REPLACE_ME: "REPLACE_ME"
+    )
+    visit "/crud/things/#{thing.id}/edit"
+    fill_in "REPLACE_ME", with: "REPLACE_ME"
+    click_on "update"
+
+    expect(page).to have_css ".notice", text: "Thing updated"
+    expect(page).to have_current_path crud_thing_path(thing)
+    expect(page).to have_css "td", text: "REPLACE_ME"
+  end
+end

--- a/spec/fixtures/generators/crud_pages/spec/system/crud/things/admin_views_thing_spec.rb
+++ b/spec/fixtures/generators/crud_pages/spec/system/crud/things/admin_views_thing_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe "Admin views thing" do
+  include_context "admin password matches"
+
+  scenario "from list page" do
+    thing = FactoryBot.create(:thing)
+    visit "/crud/things"
+    click_on thing.id.to_s
+    expect(page).to have_css "h1", text: "Thing #{thing.id}"
+    expect(page).to have_css "a", text: "Thing List"
+    expect(page).to have_current_path crud_thing_path(thing)
+  end
+
+  scenario "viewing a record" do
+    thing = FactoryBot.create(
+      :thing,
+      REPLACE_ME: "REPLACE_ME"
+    )
+
+    visit "/crud/things/#{thing.id}"
+
+    actual_values = page.all("tr").map do |table_row|
+      table_row.all("td").map(&:text)
+    end
+
+    expect(actual_values).to eq(
+      [
+        ["REPLACE_ME", "REPLACE_ME"],
+        ["Created At", thing.created_at.to_fs],
+        ["Updated At", thing.updated_at.to_fs]
+      ]
+    )
+  end
+
+  scenario "views random record" do
+    thing = FactoryBot.create(:thing)
+    expect(Thing).to receive(:random).and_return(thing)
+
+    visit "/crud/things"
+    click_on "Random Thing"
+
+    expect(page).to have_css "h1", text: "Thing #{thing.id}"
+    expect(page).to have_current_path crud_thing_path(thing)
+  end
+end

--- a/spec/fixtures/generators/crud_pages/spec/system/crud/things/admin_views_things_spec.rb
+++ b/spec/fixtures/generators/crud_pages/spec/system/crud/things/admin_views_things_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe "Admin views things" do
+  include_context "admin password matches"
+
+  scenario "from dashboard" do
+    visit "/dashboard"
+    click_on "Things"
+    expect(page).to have_css "h1", text: "Things"
+    expect(page).to have_current_path crud_things_path
+  end
+
+  scenario "with no records" do
+    visit "/crud/things"
+    expect(page.all("tbody tr").count).to eq 0
+  end
+
+  scenario "with a page of records" do
+    FactoryBot.create_list(:thing, 3)
+    visit "/crud/things"
+    expect(page.all("tbody tr").count).to eq 3
+    expect(page).to_not have_css "nav.pagination"
+  end
+
+  scenario "with two pages of records" do
+    FactoryBot.create_list(:thing, 4)
+    visit "/crud/things"
+    expect(page.all("tbody tr").count).to eq 3
+    expect(page).to have_css "nav.pagination"
+  end
+end

--- a/spec/fixtures/generators/crud_pages_stdout.txt
+++ b/spec/fixtures/generators/crud_pages_stdout.txt
@@ -1,0 +1,14 @@
+      create  app/controllers/crud/things_controller.rb
+       route  namespace :crud do
+                resources :things
+              end
+      create  app/views/crud/things/_form.html.haml
+      create  app/views/crud/things/edit.html.haml
+      create  app/views/crud/things/index.html.haml
+      create  app/views/crud/things/new.html.haml
+      create  app/views/crud/things/show.html.haml
+      create  spec/system/crud/things/admin_creates_thing_spec.rb
+      create  spec/system/crud/things/admin_edits_thing_spec.rb
+      create  spec/system/crud/things/admin_views_things_spec.rb
+      create  spec/system/crud/things/admin_views_thing_spec.rb
+      insert  app/views/dashboard/show.html.haml

--- a/spec/generator/crud/pages_generator_spec.rb
+++ b/spec/generator/crud/pages_generator_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+require_relative "../../../lib/generators/crud/pages/pages_generator"
+
+describe Crud::PagesGenerator, type: :generator do
+  it "generates all the things" do
+    FileUtils.rm_rf("tmp/generators")
+    FileUtils.mkdir_p("tmp/generators/crud_pages/config")
+    FileUtils.cp("config/routes.rb", "tmp/generators/crud_pages/config/routes.rb")
+    FileUtils.mkdir_p("tmp/generators/crud_pages/app/views/dashboard")
+    FileUtils.cp("app/views/dashboard/show.html.haml", "tmp/generators/crud_pages/app/views/dashboard/show.html.haml")
+
+    args = ["Thing"]
+    options = {}
+    config = {}
+    generator = Crud::PagesGenerator.new(args, options, config)
+    generator.destination_root = "tmp/generators/crud_pages"
+
+    expected_output = File.read("spec/fixtures/generators/crud_pages_stdout.txt")
+
+    expect do
+      generator.invoke_all
+    end.to output(expected_output).to_stdout
+
+    actual_paths = Dir.glob("tmp/generators/crud_pages/**/*").select(&File.method(:file?))
+    expected_paths = Dir.glob("spec/fixtures/generators/crud_pages/**/*").select(&File.method(:file?))
+
+    actual_paths.zip(expected_paths).each do |(actual_path, expected_path)|
+      actual_filename = actual_path.gsub("tmp/generators", "")
+      expected_filename = expected_path.gsub("spec/fixtures/generators", "")
+      expect(actual_filename).to eq expected_filename
+      expect(FileUtils.compare_file(actual_path, expected_path)).to eq true
+    end
+  end
+end


### PR DESCRIPTION
This is quite the PR! I've been working on and off on this for a while but the idea is to extract the patterns in my CRUD pages into a Rails generator so that I can spit out all the various bits and then just do some minor edits to fit whatever model I'm working with. So in scope for this PR is something like creating a CRUD controller but out of scope would be something like setting up the form partial to match the attributes of the model. I figure the former is very scriptable while the latter takes some reflection and trickery that's not worth it.

It's possible I will use this and tire of the minimal toil of doing those manual edits but for now this is SO much better than doing it all myself that I need to aim for good and not let great stand in the way of shipping.

I think the actual generator is pretty boring - it's mostly just taking templates and populating them with model names. I took mainly from the existing `Book` or `GiftIdea` files and then adapted them as needed.

What I'm more excited by is the way I tested this. I only added a single test but here's what it does:

* establishes a folder in the `tmp` area that can be used as the destination for the generator
* runs the generator
* asserts about what is written to stdout
* asserts about the file names that were generated
* asserts about the file contents that were generated

This was not trivial to setup but ultimately I think about it kinda like snapshot testing so all I did was run the generator and then commit the files that were generated to a fixtures folder. That is like my initial snapshot. Then as things evolve over time I can update these files and keep things in the green. Pretty nice!