### PR TITLE
Fix recurring schedules

### DIFF
--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -18,13 +18,13 @@ production:
     schedule: every hour
   crawl_artworks_job:
     class: CrawlArtworksJob
-    schedule: every day at at 4am in UTC
+    schedule: every day at 4am in UTC
   drain_hooks_job:
     class: DrainHooksJob
-    schedule: every day at at 5am in UTC
+    schedule: every day at 5am in UTC
   ensure_current_lineup_job:
     class: EnsureCurrentLineupJob
-    schedule: every day at at 6am in UTC
+    schedule: every day at 6am in UTC
   produce_daily_packet_job:
     class: ProduceDailyPacketJob
-    schedule: every day at at 7am in UTC
+    schedule: every day at 7am in UTC


### PR DESCRIPTION
I'm not really sure how this slipped by but I had this typo in the recurring schedules and that causes the workers to crash when starting on Heroku. I really wish there was some sort of check command that would detect this but oh well.