### PR TITLE
Fix JSON fields in CRUD pages

### DIFF
--- a/app/controllers/crud/post_bin_requests_controller.rb
+++ b/app/controllers/crud/post_bin_requests_controller.rb
@@ -37,6 +37,12 @@ class Crud::PostBinRequestsController < ApplicationController
   private
 
   def post_bin_request_params
-    params.require(:post_bin_request).permit(PostBinRequest.permitted_params)
+    permitted_params = params.require(:post_bin_request).permit(PostBinRequest.permitted_params)
+
+    {
+      body: permitted_params[:body],
+      headers: MaybeJson.parse(permitted_params[:headers]),
+      params: MaybeJson.parse(permitted_params[:params])
+    }
   end
 end

--- a/app/controllers/crud/raw_hooks_controller.rb
+++ b/app/controllers/crud/raw_hooks_controller.rb
@@ -37,6 +37,12 @@ class Crud::RawHooksController < ApplicationController
   private
 
   def raw_hook_params
-    params.require(:raw_hook).permit(RawHook.permitted_params)
+    permitted_params = params.require(:raw_hook).permit(RawHook.permitted_params)
+
+    {
+      body: permitted_params[:body],
+      headers: MaybeJson.parse(permitted_params[:headers]),
+      params: MaybeJson.parse(permitted_params[:params])
+    }
   end
 end

--- a/app/views/crud/post_bin_requests/_form.html.haml
+++ b/app/views/crud/post_bin_requests/_form.html.haml
@@ -1,5 +1,0 @@
-= form_with model: [:crud, post_bin_request] do |form|
-  = form.text_area :body, placeholder: "body"
-  = form.text_area :headers, placeholder: "headers"
-  = form.text_area :params, placeholder: "params"
-  = form.button button_label

--- a/app/views/crud/post_bin_requests/edit.html.haml
+++ b/app/views/crud/post_bin_requests/edit.html.haml
@@ -2,4 +2,8 @@
 
 %p= link_to "Show Post Bin Request", crud_post_bin_request_path(post_bin_request)
 
-= render "form", post_bin_request: post_bin_request, button_label: "update"
+= form_with model: [:crud, post_bin_request] do |form|
+  = form.text_area :headers, placeholder: "headers", value: post_bin_request.headers.to_json
+  = form.text_area :params, placeholder: "params", value: post_bin_request.params.to_json
+  = form.text_area :body, placeholder: "body"
+  = form.button "update"

--- a/app/views/crud/post_bin_requests/new.html.haml
+++ b/app/views/crud/post_bin_requests/new.html.haml
@@ -2,4 +2,8 @@
 
 %p= link_to "Post Bin Request List", crud_post_bin_requests_path
 
-= render "form", post_bin_request: post_bin_request, button_label: "create"
+= form_with model: [:crud, post_bin_request] do |form|
+  = form.text_area :headers, placeholder: "headers"
+  = form.text_area :params, placeholder: "params"
+  = form.text_area :body, placeholder: "body"
+  = form.button "create"

--- a/app/views/crud/raw_hooks/_form.html.haml
+++ b/app/views/crud/raw_hooks/_form.html.haml
@@ -1,5 +1,0 @@
-= form_with model: [:crud, raw_hook] do |form|
-  = form.text_area :body, placeholder: "body"
-  = form.text_area :headers, placeholder: "headers"
-  = form.text_area :params, placeholder: "params"
-  = form.button button_label

--- a/app/views/crud/raw_hooks/edit.html.haml
+++ b/app/views/crud/raw_hooks/edit.html.haml
@@ -2,4 +2,8 @@
 
 %p= link_to "Show Raw Hook", crud_raw_hook_path(raw_hook)
 
-= render "form", raw_hook: raw_hook, button_label: "update"
+= form_with model: [:crud, raw_hook] do |form|
+  = form.text_area :headers, placeholder: "headers", value: raw_hook.headers.to_json
+  = form.text_area :params, placeholder: "params", value: raw_hook.params.to_json
+  = form.text_area :body, placeholder: "body"
+  = form.button "update"

--- a/app/views/crud/raw_hooks/new.html.haml
+++ b/app/views/crud/raw_hooks/new.html.haml
@@ -2,4 +2,8 @@
 
 %p= link_to "Raw Hook List", crud_raw_hooks_path
 
-= render "form", raw_hook: raw_hook, button_label: "create"
+= form_with model: [:crud, raw_hook] do |form|
+  = form.text_area :headers, placeholder: "headers"
+  = form.text_area :params, placeholder: "params"
+  = form.text_area :body, placeholder: "body"
+  = form.button "create"

--- a/lib/maybe_json.rb
+++ b/lib/maybe_json.rb
@@ -1,0 +1,7 @@
+module MaybeJson
+  def self.parse(source, opts = nil)
+    JSON.parse(source.to_s, opts)
+  rescue JSON::ParserError
+    nil
+  end
+end

--- a/spec/lib/maybe_json_spec.rb
+++ b/spec/lib/maybe_json_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+describe MaybeJson do
+  describe ".parse" do
+    let(:result) { MaybeJson.parse(source) }
+
+    context "when source is nil" do
+      let(:source) { nil }
+
+      it "returns nil" do
+        expect(result).to be_nil
+      end
+    end
+
+    context "when source is empty string" do
+      let(:source) { "" }
+
+      it "returns nil" do
+        expect(result).to be_nil
+      end
+    end
+
+    context "when source is invalid" do
+      let(:source) { "invalid" }
+
+      it "returns nil" do
+        expect(result).to be_nil
+      end
+    end
+
+    context "when source is valid" do
+      let(:source) { '{"foo":"bar"}' }
+
+      it "parses source" do
+        expect(result).to eq({"foo" => "bar"})
+      end
+    end
+
+    context "with some options" do
+      it "passes those options along" do
+        source = '{"foo":"bar"}'
+        opts = {symbolize_names: true}
+        expect(JSON).to receive(:parse).with(source, opts).and_call_original
+        result = MaybeJson.parse(source, opts)
+        expect(result).to eq({foo: "bar"})
+      end
+    end
+  end
+end

--- a/spec/system/crud/post_bin_requests/admin_creates_post_bin_request_spec.rb
+++ b/spec/system/crud/post_bin_requests/admin_creates_post_bin_request_spec.rb
@@ -35,7 +35,7 @@ describe "Admin creates post bin request" do
     )
 
     expect(page.all("h2").map(&:text)).to eq %w[Headers Params Body]
-    expect(page.all("pre code").map(&:text)).to eq(
+    expect(page.all("pre code").map(&:native).map(&:text)).to eq(
       [
         JSON.pretty_generate(post_bin_request.headers),
         JSON.pretty_generate(post_bin_request.params),

--- a/spec/system/crud/post_bin_requests/admin_views_post_bin_request_spec.rb
+++ b/spec/system/crud/post_bin_requests/admin_views_post_bin_request_spec.rb
@@ -16,8 +16,8 @@ describe "Admin views post bin request" do
     post_bin_request = FactoryBot.create(
       :post_bin_request,
       body: "payload",
-      headers: {"x-header-name" => "header-value"}.to_json,
-      params: {"param-name" => "param-value"}.to_json
+      headers: {"x-header-name" => "header-value"},
+      params: {"param-name" => "param-value"}
     )
 
     visit "/crud/post_bin_requests/#{post_bin_request.id}"
@@ -34,7 +34,7 @@ describe "Admin views post bin request" do
     )
 
     expect(page.all("h2").map(&:text)).to eq %w[Headers Params Body]
-    expect(page.all("pre code").map(&:text)).to eq(
+    expect(page.all("pre code").map(&:native).map(&:text)).to eq(
       [
         JSON.pretty_generate(post_bin_request.headers),
         JSON.pretty_generate(post_bin_request.params),

--- a/spec/system/crud/raw_hooks/admin_creates_raw_hook_spec.rb
+++ b/spec/system/crud/raw_hooks/admin_creates_raw_hook_spec.rb
@@ -42,7 +42,7 @@ describe "Admin creates raw hook" do
     )
 
     expect(page.all("h2").map(&:text)).to eq %w[Headers Params Body]
-    expect(page.all("pre code").map(&:text)).to eq(
+    expect(page.all("pre code").map(&:native).map(&:text)).to eq(
       [
         JSON.pretty_generate(raw_hook.headers),
         JSON.pretty_generate(raw_hook.params),

--- a/spec/system/crud/raw_hooks/admin_views_raw_hook_spec.rb
+++ b/spec/system/crud/raw_hooks/admin_views_raw_hook_spec.rb
@@ -16,8 +16,8 @@ describe "Admin views raw hook" do
     raw_hook = FactoryBot.create(
       :raw_hook,
       body: "payload",
-      headers: {"x-header-name" => "header-value"}.to_json,
-      params: {"param-name" => "param-value"}.to_json
+      headers: {"x-header-name" => "header-value"},
+      params: {"param-name" => "param-value"}
     )
 
     visit "/crud/raw_hooks/#{raw_hook.id}"
@@ -34,7 +34,7 @@ describe "Admin views raw hook" do
     )
 
     expect(page.all("h2").map(&:text)).to eq %w[Headers Params Body]
-    expect(page.all("pre code").map(&:text)).to eq(
+    expect(page.all("pre code").map(&:native).map(&:text)).to eq(
       [
         JSON.pretty_generate(raw_hook.headers),
         JSON.pretty_generate(raw_hook.params),


### PR DESCRIPTION
There were a few related issues around JSON fields in CRUD pages so this PR addresses them.

<details><summary>Before and After Screenshots</summary>

### Show Page Before
<img width="2400" height="1800" alt="show-page-before" src="https://github.com/user-attachments/assets/3032df00-612c-4028-add0-02f087fa672b" />

### Show Page After
<img width="2400" height="1800" alt="show-page-after" src="https://github.com/user-attachments/assets/789c39ea-63dc-44f7-9a6e-b02621de3c87" />

### Edit Page Before
<img width="2400" height="1800" alt="edit-page-before" src="https://github.com/user-attachments/assets/e80da6b8-6675-4a05-8305-1e5809544134" />

### Edit Page After
<img width="2400" height="1800" alt="edit-page-after" src="https://github.com/user-attachments/assets/a3f636c4-e551-4ee0-bc6c-0b79c6982a36" />

</details> 

I also extracted a module to either return parsed JSON or nil which I'm calling `MaybeJson` which was fun. If I end up wanting this elsewhere maybe this could be moved to a gem.