### PR TITLE
Support tracking workouts and training

### DIFF
--- a/app/controllers/crud/training_activities_controller.rb
+++ b/app/controllers/crud/training_activities_controller.rb
@@ -1,0 +1,42 @@
+class Crud::TrainingActivitiesController < ApplicationController
+  expose(:training_activity)
+  expose(:training_activities) do
+    TrainingActivity.order(created_at: :desc).page(params[:page])
+  end
+
+  def show
+    redirect_to crud_training_activity_path(TrainingActivity.random) if random_id?
+  end
+
+  def create
+    if training_activity.save
+      flash.notice = "Training Activity created"
+      redirect_to crud_training_activity_path(training_activity)
+    else
+      flash.alert = training_activity.errors.full_messages.to_sentence
+      redirect_to new_crud_training_activity_path
+    end
+  end
+
+  def update
+    if training_activity.update(training_activity_params)
+      flash.notice = "Training Activity updated"
+      redirect_to crud_training_activity_path(training_activity)
+    else
+      flash.alert = training_activity.errors.full_messages.to_sentence
+      redirect_to edit_crud_training_activity_path(training_activity)
+    end
+  end
+
+  def destroy
+    training_activity.destroy
+    flash.notice = "Training Activity deleted"
+    redirect_to crud_training_activities_path
+  end
+
+  private
+
+  def training_activity_params
+    params.require(:training_activity).permit(TrainingActivity.permitted_params)
+  end
+end

--- a/app/controllers/crud/training_days_controller.rb
+++ b/app/controllers/crud/training_days_controller.rb
@@ -1,0 +1,42 @@
+class Crud::TrainingDaysController < ApplicationController
+  expose(:training_day)
+  expose(:training_days) do
+    TrainingDay.order(created_at: :desc).page(params[:page])
+  end
+
+  def show
+    redirect_to crud_training_day_path(TrainingDay.random) if random_id?
+  end
+
+  def create
+    if training_day.save
+      flash.notice = "Training Day created"
+      redirect_to crud_training_day_path(training_day)
+    else
+      flash.alert = training_day.errors.full_messages.to_sentence
+      redirect_to new_crud_training_day_path
+    end
+  end
+
+  def update
+    if training_day.update(training_day_params)
+      flash.notice = "Training Day updated"
+      redirect_to crud_training_day_path(training_day)
+    else
+      flash.alert = training_day.errors.full_messages.to_sentence
+      redirect_to edit_crud_training_day_path(training_day)
+    end
+  end
+
+  def destroy
+    training_day.destroy
+    flash.notice = "Training Day deleted"
+    redirect_to crud_training_days_path
+  end
+
+  private
+
+  def training_day_params
+    params.require(:training_day).permit(TrainingDay.permitted_params)
+  end
+end

--- a/app/controllers/crud/workouts_controller.rb
+++ b/app/controllers/crud/workouts_controller.rb
@@ -1,0 +1,42 @@
+class Crud::WorkoutsController < ApplicationController
+  expose(:workout)
+  expose(:workouts) do
+    Workout.order(created_at: :desc).page(params[:page])
+  end
+
+  def show
+    redirect_to crud_workout_path(Workout.random) if random_id?
+  end
+
+  def create
+    if workout.save
+      flash.notice = "Workout created"
+      redirect_to crud_workout_path(workout)
+    else
+      flash.alert = workout.errors.full_messages.to_sentence
+      redirect_to new_crud_workout_path
+    end
+  end
+
+  def update
+    if workout.update(workout_params)
+      flash.notice = "Workout updated"
+      redirect_to crud_workout_path(workout)
+    else
+      flash.alert = workout.errors.full_messages.to_sentence
+      redirect_to edit_crud_workout_path(workout)
+    end
+  end
+
+  def destroy
+    workout.destroy
+    flash.notice = "Workout deleted"
+    redirect_to crud_workouts_path
+  end
+
+  private
+
+  def workout_params
+    params.require(:workout).permit(Workout.permitted_params)
+  end
+end

--- a/app/controllers/training_calendar_controller.rb
+++ b/app/controllers/training_calendar_controller.rb
@@ -1,0 +1,7 @@
+class TrainingCalendarController < ApplicationController
+  expose(:calendar_report) do
+    year = params[:year]
+    month = params[:month]
+    TrainingDay::CalendarReport.new(year, month)
+  end
+end

--- a/app/controllers/training_days_controller.rb
+++ b/app/controllers/training_days_controller.rb
@@ -1,0 +1,28 @@
+class TrainingDaysController < ApplicationController
+  expose(:training_day)
+
+  def create
+    year, month, _day = params[:training_day][:date].split("-").map(&:to_i)
+    TrainingDay.populate(year, month)
+    redirect_to training_calendar_path(year: year, month: month)
+  end
+
+  def update
+    if training_day.update(training_day_params)
+      flash.notice = "Training Day updated"
+    else
+      flash.alert = training_day.errors.full_messages.to_sentence
+    end
+
+    week_report_params = TrainingDay::WeekReport.params_for(training_day.date)
+    redirect_to training_week_path(week_report_params)
+  end
+
+  private
+
+  def training_day_params
+    training_activity_params = [training_activities_attributes: [:_destroy, :id, :workout_id]]
+    permitted_params = TrainingDay.permitted_params + training_activity_params
+    params.require(:training_day).permit(permitted_params)
+  end
+end

--- a/app/controllers/training_week_controller.rb
+++ b/app/controllers/training_week_controller.rb
@@ -1,0 +1,9 @@
+class TrainingWeekController < ApplicationController
+  layout "wide"
+
+  expose(:week_report) do
+    year = params[:year]
+    number = params[:number]
+    TrainingDay::WeekReport.new(year, number)
+  end
+end

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -27,6 +27,26 @@ module ApplicationHelper
     placeholder_option + format_options
   end
 
+  def training_day_intensity_options
+    placeholder_option = [["please select", ""]]
+
+    intensity_options = TrainingDay::INTENSITIES.map do |intensity|
+      [intensity, intensity]
+    end
+
+    placeholder_option + intensity_options
+  end
+
+  def training_day_with_coach_options
+    placeholder_option = [["please select", ""]]
+
+    with_coach_options = [true, false].map do |with_coach|
+      [with_coach, with_coach]
+    end
+
+    placeholder_option + with_coach_options
+  end
+
   def last_week_path(work_week)
     target_date = work_week.target_date - 1.week
     target = TargetSlug.for(target_date)

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,12 +1,43 @@
 module ApplicationHelper
-  def attr_table_value(value)
+  def workout_options
+    placeholder_option = [["please select", ""]]
+
+    title_options = Workout.all.map do |workout|
+      [workout.title, workout.id]
+    end
+
+    placeholder_option + title_options
+  end
+
+  def calendar_color(outcome)
+    map = {
+      filler: "bg-black",
+      going: "bg-dark-gray",
+      missed: "bg-white",
+      went: "bg-purple"
+    }
+
+    map[outcome]
+  end
+
+  def week_color(outcome)
+    map = {
+      going: "text-off-white",
+      missed: "text-black",
+      went: "text-off-white"
+    }
+
+    map[outcome]
+  end
+
+  def attr_table_value(key, value)
     if value.nil?
       "NIL"
     elsif value.is_a?(Date)
       value.to_fs
     elsif value.is_a?(Time)
       in_tz(value)
-    elsif value.is_a?(Integer)
+    elsif value.is_a?(Integer) && !key.ends_with?("ID")
       value.to_fs(:delimited)
     else
       value

--- a/app/models/daily_packet.rb
+++ b/app/models/daily_packet.rb
@@ -38,12 +38,11 @@ class DailyPacket < ApplicationRecord
   end
 
   def chore_list
-    chores = Chore
-      .where(assignee: "jon")
-      .where("? = ANY(due_days)", built_on.wday)
-      .order(created_at: :asc)
-
     chores.pluck(:title).map(&:downcase)
+  end
+
+  def chores
+    @chores ||= generate_chores
   end
 
   def start_list
@@ -64,5 +63,27 @@ class DailyPacket < ApplicationRecord
 
   def built_on_weekend?
     built_on.saturday? || built_on.sunday?
+  end
+
+  def workouts_title
+    "#{calendar_report.period_start.strftime("%B")} Workouts"
+  end
+
+  def calendar_report
+    @calendar_report ||= generate_calendar_report
+  end
+
+  private
+
+  def generate_chores
+    Chore
+      .where(assignee: "jon")
+      .where("? = ANY(due_days)", built_on.wday)
+      .order(created_at: :asc)
+  end
+
+  def generate_calendar_report
+    month, year = TrainingDay::CalendarReport.params_for(built_on).values
+    TrainingDay::CalendarReport.new(year, month)
   end
 end

--- a/app/models/daily_packet/pdf_view.rb
+++ b/app/models/daily_packet/pdf_view.rb
@@ -76,6 +76,28 @@ class DailyPacket::PdfView < ActiveRecord::AssociatedObject
       text "Feedbin Stats", style: :bold, size: 20
       text daily_packet.feedbin_unread_phrase, size: 12
       text daily_packet.feedbin_oldest_phrase, size: 12
+
+      move_down 20
+
+      text daily_packet.workouts_title, style: :bold, size: 20
+      move_down 5
+
+      day_gap = 10
+      daily_packet.calendar_report.training_day_groups.each do |training_day_group|
+        training_day_group.each_with_index do |training_day, offset|
+          next if training_day.is_a? TrainingDay::FillerDay
+
+          box_x = offset * 10 + day_gap * offset
+
+          if training_day.outcome == :went
+            fill_rectangle [box_x, 0], 10, 10
+          else
+            stroke_rectangle [box_x, 0], 10, 10
+          end
+        end
+
+        move_down 20
+      end
     end
   end
 

--- a/app/models/training_activity.rb
+++ b/app/models/training_activity.rb
@@ -1,0 +1,4 @@
+class TrainingActivity < ApplicationRecord
+  belongs_to :training_day
+  belongs_to :workout
+end

--- a/app/models/training_activity.rb
+++ b/app/models/training_activity.rb
@@ -1,4 +1,20 @@
 class TrainingActivity < ApplicationRecord
   belongs_to :training_day
   belongs_to :workout
+
+  def self.permitted_params
+    [
+      :training_day_id,
+      :workout_id
+    ]
+  end
+
+  def table_attrs
+    [
+      ["Training Day ID", training_day_id],
+      ["Workout ID", workout_id],
+      ["Created At", created_at],
+      ["Updated At", updated_at]
+    ]
+  end
 end

--- a/app/models/training_day.rb
+++ b/app/models/training_day.rb
@@ -1,6 +1,29 @@
 class TrainingDay < ApplicationRecord
+  INTENSITIES = %w[lift recovery rest]
+
   has_many :training_activities, dependent: :destroy
+
   validates :date, presence: true
-  validates :intensity, presence: true, inclusion: {in: %w[lift recovery rest]}
+  validates :intensity, presence: true, inclusion: {in: INTENSITIES}
   validates :with_coach, inclusion: {in: [true, false]}
+
+  def self.permitted_params
+    [
+      :date,
+      :completed_at,
+      :intensity,
+      :with_coach
+    ]
+  end
+
+  def table_attrs
+    [
+      ["Date", date],
+      ["Intensity", intensity],
+      ["With Coach", with_coach],
+      ["Completed At", completed_at],
+      ["Created At", created_at],
+      ["Updated At", updated_at]
+    ]
+  end
 end

--- a/app/models/training_day.rb
+++ b/app/models/training_day.rb
@@ -1,0 +1,6 @@
+class TrainingDay < ApplicationRecord
+  has_many :training_activities, dependent: :destroy
+  validates :date, presence: true
+  validates :intensity, presence: true, inclusion: {in: %w[lift recovery rest]}
+  validates :with_coach, inclusion: {in: [true, false]}
+end

--- a/app/models/training_day.rb
+++ b/app/models/training_day.rb
@@ -2,10 +2,28 @@ class TrainingDay < ApplicationRecord
   INTENSITIES = %w[lift recovery rest]
 
   has_many :training_activities, dependent: :destroy
+  accepts_nested_attributes_for :training_activities, allow_destroy: true, reject_if: :all_blank
 
   validates :date, presence: true
   validates :intensity, presence: true, inclusion: {in: INTENSITIES}
   validates :with_coach, inclusion: {in: [true, false]}
+
+  def self.populate(year, month)
+    all_month = Date.new(year, month, 1).all_month
+    all_month.each do |date|
+      next if TrainingDay.where(date: date).any?
+
+      lift_day = date.monday? || date.wednesday? || date.friday?
+      intensity = lift_day ? "lift" : "recovery"
+      attrs = {
+        date: date,
+        intensity: intensity,
+        with_coach: date.monday?
+      }
+
+      TrainingDay.create(attrs)
+    end
+  end
 
   def self.permitted_params
     [
@@ -25,5 +43,20 @@ class TrainingDay < ApplicationRecord
       ["Created At", created_at],
       ["Updated At", updated_at]
     ]
+  end
+
+  def outcome
+    if intensity == "rest"
+      :missed
+    elsif completed_at.nil?
+      :going
+    else
+      :went
+    end
+  end
+
+  def summary
+    suffix = with_coach ? "with coach" : nil
+    [intensity, suffix].compact.join(" ")
   end
 end

--- a/app/models/training_day/calendar_report.rb
+++ b/app/models/training_day/calendar_report.rb
@@ -1,0 +1,45 @@
+class TrainingDay::CalendarReport
+  def self.default_params
+    date = Date.today
+    params_for(date)
+  end
+
+  def self.params_for(start)
+    month, year = start.strftime("%m %Y").split
+    {month: month, year: year}
+  end
+
+  attr_reader :period_start
+
+  def initialize(year, month)
+    @period_start = Date.new(
+      year.to_i,
+      month.to_i
+    )
+  end
+
+  def title
+    @period_start.strftime("%b %Y")
+  end
+
+  def prev_params
+    prev_start = @period_start - 1.month
+    self.class.params_for(prev_start)
+  end
+
+  def next_params
+    next_start = @period_start + 1.month
+    self.class.params_for(next_start)
+  end
+
+  def training_day_groups
+    all_month = @period_start.all_month
+    month_days = TrainingDay.where(date: all_month).order(date: :asc)
+    return [] unless month_days.any?
+
+    before_filler = TrainingDay::FillerDay.fill_before(all_month.first)
+    after_filler = TrainingDay::FillerDay.fill_after(all_month.last)
+    days = before_filler + month_days + after_filler
+    days.in_groups_of(7)
+  end
+end

--- a/app/models/training_day/filler_day.rb
+++ b/app/models/training_day/filler_day.rb
@@ -1,0 +1,29 @@
+class TrainingDay::FillerDay
+  def self.fill_after(date)
+    return [] unless date == date.end_of_month
+
+    filler_offsets = 1.upto(6 - date.wday).to_a
+    filler_offsets.map { |offset| new(date + offset.days) }
+  end
+
+  def self.fill_before(date)
+    return [] unless date == date.beginning_of_month
+
+    filler_offsets = date.wday.downto(1).to_a
+    filler_offsets.map { |offset| new(date - offset.days) }
+  end
+
+  attr_reader :date
+
+  def initialize(date)
+    @date = date
+  end
+
+  def intensity
+    "filler"
+  end
+
+  def outcome
+    :filler
+  end
+end

--- a/app/models/training_day/week_report.rb
+++ b/app/models/training_day/week_report.rb
@@ -1,0 +1,58 @@
+class TrainingDay::WeekReport
+  def self.default_params
+    date = Date.today
+    params_for(date)
+  end
+
+  def self.params_for(date)
+    date = date.sunday? ? date + 1.day : date
+
+    {
+      number: date.strftime("%V"),
+      year: date.cwyear
+    }
+  end
+
+  def initialize(year, number)
+    @period_start = Date.commercial(
+      year.to_i,
+      number.to_i
+    )
+  end
+
+  def title
+    last_day.strftime("%Y-%V")
+  end
+
+  def training_days
+    TrainingDay.where(date: all_week).order(date: :asc)
+  end
+
+  def all_week
+    @period_start.all_week(:sunday)
+  end
+
+  def month_dates
+    dates = [first_day]
+    dates << last_day if first_day.month != last_day.month
+    dates
+  end
+
+  def first_day
+    all_week.first
+  end
+
+  def last_day
+    all_week.last
+  end
+
+  def prev_params
+    date = last_day - 1.week
+    self.class.params_for(date)
+  end
+
+  def next_params
+    date = last_day + 1.week
+    self.class.params_for(date)
+  end
+end

--- a/app/models/workout.rb
+++ b/app/models/workout.rb
@@ -1,0 +1,4 @@
+class Workout < ApplicationRecord
+  has_many :training_activities, dependent: :destroy
+  validates :title, presence: true
+end

--- a/app/models/workout.rb
+++ b/app/models/workout.rb
@@ -1,4 +1,18 @@
 class Workout < ApplicationRecord
   has_many :training_activities, dependent: :destroy
   validates :title, presence: true
+
+  def self.permitted_params
+    [
+      :title
+    ]
+  end
+
+  def table_attrs
+    [
+      ["Title", title],
+      ["Created At", created_at],
+      ["Updated At", updated_at]
+    ]
+  end
 end

--- a/app/views/application/_attrs_table.html.haml
+++ b/app/views/application/_attrs_table.html.haml
@@ -3,4 +3,4 @@
     - attrs.each do |(key, value)|
       %tr
         %td= key
-        %td.text-right= attr_table_value(value)
+        %td.text-right= attr_table_value(key, value)

--- a/app/views/crud/training_activities/_form.html.haml
+++ b/app/views/crud/training_activities/_form.html.haml
@@ -1,0 +1,4 @@
+= form_with model: [:crud, training_activity] do |form|
+  = form.text_field :training_day_id, placeholder: "training_day_id"
+  = form.text_field :workout_id, placeholder: "workout_id"
+  = form.button button_label

--- a/app/views/crud/training_activities/edit.html.haml
+++ b/app/views/crud/training_activities/edit.html.haml
@@ -1,0 +1,5 @@
+%h1 Edit Training Activity #{training_activity.id}
+
+%p= link_to "Show Training Activity", crud_training_activity_path(training_activity)
+
+= render "form", training_activity: training_activity, button_label: "update"

--- a/app/views/crud/training_activities/index.html.haml
+++ b/app/views/crud/training_activities/index.html.haml
@@ -1,0 +1,18 @@
+%h1 Training Activities
+
+%p= link_to "New Training Activity", new_crud_training_activity_path
+
+%p= link_to "Random Training Activity", crud_training_activity_path("random")
+
+%table
+  %thead
+    %tr
+      %th ID
+      %th.text-right Created At
+  %tbody
+    - training_activities.each do |training_activity|
+      %tr
+        %td= link_to training_activity.id, crud_training_activity_path(training_activity)
+        %td.text-right= in_tz training_activity.created_at
+
+= paginate training_activities

--- a/app/views/crud/training_activities/new.html.haml
+++ b/app/views/crud/training_activities/new.html.haml
@@ -1,0 +1,5 @@
+%h1 New Training Activity
+
+%p= link_to "Training Activity List", crud_training_activities_path
+
+= render "form", training_activity: training_activity, button_label: "create"

--- a/app/views/crud/training_activities/show.html.haml
+++ b/app/views/crud/training_activities/show.html.haml
@@ -1,0 +1,9 @@
+%h1 Training Activity #{training_activity.id}
+
+%p= link_to "Training Activity List", crud_training_activities_path
+
+%p= link_to "Edit Training Activity", edit_crud_training_activity_path(training_activity)
+
+%p= link_to "Delete Training Activity", crud_training_activity_path(training_activity), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }
+
+= render partial: "attrs_table", locals: { attrs: training_activity.table_attrs }

--- a/app/views/crud/training_days/_form.html.haml
+++ b/app/views/crud/training_days/_form.html.haml
@@ -1,0 +1,6 @@
+= form_with model: [:crud, training_day] do |form|
+  = form.date_field :date, placeholder: "date"
+  = form.select :intensity, training_day_intensity_options, selected: training_day.intensity
+  = form.select :with_coach, training_day_with_coach_options, selected: training_day.with_coach
+  = form.datetime_local_field :completed_at, placeholder: "completed at"
+  = form.button button_label

--- a/app/views/crud/training_days/edit.html.haml
+++ b/app/views/crud/training_days/edit.html.haml
@@ -1,0 +1,5 @@
+%h1 Edit Training Day #{training_day.id}
+
+%p= link_to "Show Training Day", crud_training_day_path(training_day)
+
+= render "form", training_day: training_day, button_label: "update"

--- a/app/views/crud/training_days/index.html.haml
+++ b/app/views/crud/training_days/index.html.haml
@@ -1,0 +1,18 @@
+%h1 Training Days
+
+%p= link_to "New Training Day", new_crud_training_day_path
+
+%p= link_to "Random Training Day", crud_training_day_path("random")
+
+%table
+  %thead
+    %tr
+      %th ID
+      %th.text-right Created At
+  %tbody
+    - training_days.each do |training_day|
+      %tr
+        %td= link_to training_day.id, crud_training_day_path(training_day)
+        %td.text-right= in_tz training_day.created_at
+
+= paginate training_days

--- a/app/views/crud/training_days/new.html.haml
+++ b/app/views/crud/training_days/new.html.haml
@@ -1,0 +1,5 @@
+%h1 New Training Day
+
+%p= link_to "Training Day List", crud_training_days_path
+
+= render "form", training_day: training_day, button_label: "create"

--- a/app/views/crud/training_days/show.html.haml
+++ b/app/views/crud/training_days/show.html.haml
@@ -1,0 +1,9 @@
+%h1 Training Day #{training_day.id}
+
+%p= link_to "Training Day List", crud_training_days_path
+
+%p= link_to "Edit Training Day", edit_crud_training_day_path(training_day)
+
+%p= link_to "Delete Training Day", crud_training_day_path(training_day), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }
+
+= render partial: "attrs_table", locals: { attrs: training_day.table_attrs }

--- a/app/views/crud/workouts/_form.html.haml
+++ b/app/views/crud/workouts/_form.html.haml
@@ -1,0 +1,3 @@
+= form_with model: [:crud, workout] do |form|
+  = form.text_field :title, placeholder: "title"
+  = form.button button_label

--- a/app/views/crud/workouts/edit.html.haml
+++ b/app/views/crud/workouts/edit.html.haml
@@ -1,0 +1,5 @@
+%h1 Edit Workout #{workout.id}
+
+%p= link_to "Show Workout", crud_workout_path(workout)
+
+= render "form", workout: workout, button_label: "update"

--- a/app/views/crud/workouts/index.html.haml
+++ b/app/views/crud/workouts/index.html.haml
@@ -1,0 +1,18 @@
+%h1 Workouts
+
+%p= link_to "New Workout", new_crud_workout_path
+
+%p= link_to "Random Workout", crud_workout_path("random")
+
+%table
+  %thead
+    %tr
+      %th ID
+      %th.text-right Created At
+  %tbody
+    - workouts.each do |workout|
+      %tr
+        %td= link_to workout.id, crud_workout_path(workout)
+        %td.text-right= in_tz workout.created_at
+
+= paginate workouts

--- a/app/views/crud/workouts/new.html.haml
+++ b/app/views/crud/workouts/new.html.haml
@@ -1,0 +1,5 @@
+%h1 New Workout
+
+%p= link_to "Workout List", crud_workouts_path
+
+= render "form", workout: workout, button_label: "create"

--- a/app/views/crud/workouts/show.html.haml
+++ b/app/views/crud/workouts/show.html.haml
@@ -1,0 +1,9 @@
+%h1 Workout #{workout.id}
+
+%p= link_to "Workout List", crud_workouts_path
+
+%p= link_to "Edit Workout", edit_crud_workout_path(workout)
+
+%p= link_to "Delete Workout", crud_workout_path(workout), data: { turbo_method: :delete, turbo_confirm: "Are you sure?" }
+
+= render partial: "attrs_table", locals: { attrs: workout.table_attrs }

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -37,8 +37,11 @@
 %p= link_to "Projects", crud_projects_path
 %p= link_to "Raw Hooks", crud_raw_hooks_path
 %p= link_to "Sneakers", crud_sneakers_path
+%p= link_to "Training Activities", crud_training_activities_path
+%p= link_to "Training Days", crud_training_days_path
 %p= link_to "Warm Fuzzies", crud_warm_fuzzies_path
 %p= link_to "Webhook Senders", crud_webhook_senders_path
+%p= link_to "Workouts", crud_workouts_path
 
 %h2 Api Routes
 

--- a/app/views/dashboard/show.html.haml
+++ b/app/views/dashboard/show.html.haml
@@ -20,6 +20,8 @@
 %p= link_to "Live Post Bin", post_bin_path
 %p= link_to "Model Counts", model_counts_path
 %p= link_to "Project List", project_list_path
+%p= link_to "Training Calendar", training_calendar_path(TrainingDay::CalendarReport.default_params)
+%p= link_to "Training Week", training_week_path(TrainingDay::WeekReport.default_params)
 %p= link_to "Today", today_path
 %p= link_to "Vanishing Box", vanishing_box_path
 

--- a/app/views/layouts/wide.html.haml
+++ b/app/views/layouts/wide.html.haml
@@ -3,5 +3,5 @@
   %head
     = render partial: "layouts/shared_head"
     = yield :head
-  %body.bg-off-black.text-off-white.selection:bg-pink.p-4.md:p-0.mx-8
+  %body.bg-off-black.text-off-white.selection:bg-pink.p-4.md:p-0.mx-8.max-w-none
     = render partial: "layouts/shared_main"

--- a/app/views/training_calendar/index.html.haml
+++ b/app/views/training_calendar/index.html.haml
@@ -1,0 +1,22 @@
+- content_for :header do
+  %nav.flex.justify-between.items-center.py-6
+    %p.m-0= link_to "prev", training_calendar_path(calendar_report.prev_params)
+    %h1.m-0= calendar_report.title
+    %p.m-0= link_to "next", training_calendar_path(calendar_report.next_params)
+
+%h1 Training Calendar
+
+- if calendar_report.training_day_groups.any?
+  %ul.list-none.m-0.p-0(class="space-y-[20px]")
+    - calendar_report.training_day_groups.each do |training_day_group|
+      %li.m-0.p-0
+        %a.block{href: training_week_path(TrainingDay::WeekReport.params_for(training_day_group.first.date))}
+          %ul.list-none.m-0.p-0.grid.grid-cols-7(class="gap-[20px]")
+            - training_day_group.each do |training_day|
+              %li.m-0.p-0(class="[aspect-ratio:1/1] #{calendar_color(training_day.outcome)}" title="#{training_day.date.to_fs}")
+                %span.hidden= training_day.date.to_fs
+                %span.hidden= training_day.intensity
+- else
+  = form_with model: TrainingDay.new do |form|
+    = form.hidden_field :date, value: calendar_report.period_start
+    = form.button "populate"

--- a/app/views/training_week/index.html.haml
+++ b/app/views/training_week/index.html.haml
@@ -1,0 +1,38 @@
+- content_for :header do
+  %nav.flex.justify-between.items-center.py-6(class="max-w-[800px]")
+    %p.m-0= link_to "prev", training_week_path(week_report.prev_params)
+    %h1.m-0= week_report.title
+    %p.m-0= link_to "next", training_week_path(week_report.next_params)
+  %div.flex.justify-between.border-b-8.pb-6.border-dark-gray(class="max-w-[800px]")
+    - week_report.month_dates.each do |date|
+      %p.m-0= link_to date.strftime("%b"), training_calendar_path(TrainingDay::CalendarReport.params_for(date))
+
+%h1 Training Week
+
+%ul.list-none.m-0.p-0.grid.grid-cols-7(class="gap-[20px]")
+  - week_report.training_days.each do |training_day|
+    %li.m-0.p-0.bg-off-white.text-black(class="[aspect-ratio:1/1]")
+      %dl.m-0.py-1.px-3.flex.justify-between(class="#{week_color(training_day.outcome)} #{calendar_color(training_day.outcome)}")
+        %dt.m-0.font-normal(class="#{week_color(training_day.outcome)}")= training_day.summary
+        %dd.m-0.p-0= training_day.date.strftime("%m/%d")
+
+      %ul.list-none.m-0.py-1.px-3
+        - training_day.training_activities.each do |training_activity|
+          %li.m-0.p-0= training_activity.workout.title
+
+- week_report.training_days.each do |training_day|
+  %details
+    %summary= training_day.date.strftime("%A")
+
+    = form_with model: training_day do |form|
+      = form.select :intensity, training_day_intensity_options, selected: training_day.intensity
+      = form.select :with_coach, training_day_with_coach_options, selected: training_day.with_coach
+      = form.datetime_local_field :completed_at, placeholder: "completed at"
+
+      - training_day.training_activities.build
+      = form.fields_for :training_activities do |training_activity_form|
+        = training_activity_form.select :workout_id, workout_options, selected: training_activity_form.object&.workout_id
+        = training_activity_form.label :_destroy do
+          = training_activity_form.checkbox :_destroy
+          remove
+      = form.button "update"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
   get "reading-list/:year", to: "reading_list#index", as: :reading_list
   get "sneakers", to: "sneakers#index", as: :sneakers
   get "today", to: "today#show", as: :today
+  get "training/calendar/:year/:month", to: "training_calendar#index", as: "training_calendar"
+  get "training/week/:year/:number", to: "training_week#index", as: "training_week"
   get "wishlist", to: "wishlist#index"
   get "work_weeks/:target", to: "work_weeks#show", as: :work_week
 
@@ -38,6 +40,7 @@ Rails.application.routes.draw do
 
   resources :boops, only: %i[index create]
   resources :gift_ideas, only: %i[update]
+  resources :training_days, only: %i[create update]
 
   resources :crank_users, only: %i[create new show], param: :code do
     resources :crank_counts, only: %i[create new show]

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -58,8 +58,11 @@ Rails.application.routes.draw do
     resources :projects
     resources :raw_hooks
     resources :sneakers
+    resources :training_activities
+    resources :training_days
     resources :warm_fuzzies
     resources :webhook_senders
+    resources :workouts
   end
 
   namespace :api, defaults: {format: :json} do

--- a/db/migrate/20260505123932_create_workouts.rb
+++ b/db/migrate/20260505123932_create_workouts.rb
@@ -1,0 +1,8 @@
+class CreateWorkouts < ActiveRecord::Migration[8.0]
+  def change
+    create_table :workouts do |t|
+      t.string :title, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260505123955_create_training_days.rb
+++ b/db/migrate/20260505123955_create_training_days.rb
@@ -1,0 +1,11 @@
+class CreateTrainingDays < ActiveRecord::Migration[8.0]
+  def change
+    create_table :training_days do |t|
+      t.date :date, null: false, index: {unique: true}
+      t.string :intensity, null: false
+      t.datetime :completed_at
+      t.boolean :with_coach, null: false
+      t.timestamps
+    end
+  end
+end

--- a/db/migrate/20260505124220_create_training_activities.rb
+++ b/db/migrate/20260505124220_create_training_activities.rb
@@ -1,0 +1,9 @@
+class CreateTrainingActivities < ActiveRecord::Migration[8.0]
+  def change
+    create_table :training_activities do |t|
+      t.belongs_to :training_day
+      t.belongs_to :workout
+      t.timestamps
+    end
+  end
+end

--- a/lib/tasks/training.rake
+++ b/lib/tasks/training.rake
@@ -1,0 +1,46 @@
+namespace :training do
+  desc "Populate workouts"
+  task workouts: :environment do
+    url = "https://jonallured-public.s3.amazonaws.com/workouts.csv"
+    response = Faraday.get(url)
+    rows = CSV.parse(response.body, headers: true)
+    rows.each do |row|
+      Workout.create(row.to_h)
+    end
+  end
+
+  desc "Backfill training days"
+  task training_days: :environment do
+    url = "https://jonallured-public.s3.amazonaws.com/training_days.csv"
+    response = Faraday.get(url)
+    rows = CSV.parse(response.body, headers: true)
+    rows.each do |row|
+      month, day = row["date"].split("/").map(&:to_i)
+      date = Date.new(2026, month, day)
+      attrs = {
+        completed_at: date,
+        date: date,
+        intensity: row["intensity"],
+        with_coach: row["with_coach"] == "true"
+      }
+      TrainingDay.create(attrs)
+    end
+  end
+
+  desc "Backfill training activities"
+  task training_activities: :environment do
+    url = "https://jonallured-public.s3.amazonaws.com/training_activities.csv"
+    response = Faraday.get(url)
+    rows = CSV.parse(response.body, headers: true)
+    rows.each do |row|
+      month, day = row["training_date"].split("/").map(&:to_i)
+      date = Date.new(2026, month, day)
+      training_day = TrainingDay.find_by(date: date)
+      attrs = {
+        training_day: training_day,
+        workout_id: row["workout_id"]
+      }
+      TrainingActivity.create(attrs)
+    end
+  end
+end

--- a/spec/factories/training_activity.rb
+++ b/spec/factories/training_activity.rb
@@ -1,0 +1,6 @@
+FactoryBot.define do
+  factory :training_activity do
+    training_day
+    workout
+  end
+end

--- a/spec/factories/training_day.rb
+++ b/spec/factories/training_day.rb
@@ -1,0 +1,7 @@
+FactoryBot.define do
+  factory :training_day do
+    date { Date.today }
+    intensity { "recovery" }
+    with_coach { false }
+  end
+end

--- a/spec/factories/workout.rb
+++ b/spec/factories/workout.rb
@@ -1,0 +1,5 @@
+FactoryBot.define do
+  factory :workout do
+    title { "Warm Up" }
+  end
+end

--- a/spec/fixtures/generators/crud_pages/app/views/dashboard/show.html.haml
+++ b/spec/fixtures/generators/crud_pages/app/views/dashboard/show.html.haml
@@ -38,8 +38,11 @@
 %p= link_to "Projects", crud_projects_path
 %p= link_to "Raw Hooks", crud_raw_hooks_path
 %p= link_to "Sneakers", crud_sneakers_path
+%p= link_to "Training Activities", crud_training_activities_path
+%p= link_to "Training Days", crud_training_days_path
 %p= link_to "Warm Fuzzies", crud_warm_fuzzies_path
 %p= link_to "Webhook Senders", crud_webhook_senders_path
+%p= link_to "Workouts", crud_workouts_path
 
 %h2 Api Routes
 

--- a/spec/fixtures/generators/crud_pages/app/views/dashboard/show.html.haml
+++ b/spec/fixtures/generators/crud_pages/app/views/dashboard/show.html.haml
@@ -20,6 +20,8 @@
 %p= link_to "Live Post Bin", post_bin_path
 %p= link_to "Model Counts", model_counts_path
 %p= link_to "Project List", project_list_path
+%p= link_to "Training Calendar", training_calendar_path(TrainingDay::CalendarReport.default_params)
+%p= link_to "Training Week", training_week_path(TrainingDay::WeekReport.default_params)
 %p= link_to "Today", today_path
 %p= link_to "Vanishing Box", vanishing_box_path
 

--- a/spec/fixtures/generators/crud_pages/config/routes.rb
+++ b/spec/fixtures/generators/crud_pages/config/routes.rb
@@ -15,6 +15,8 @@ Rails.application.routes.draw do
   get "reading-list/:year", to: "reading_list#index", as: :reading_list
   get "sneakers", to: "sneakers#index", as: :sneakers
   get "today", to: "today#show", as: :today
+  get "training/calendar/:year/:month", to: "training_calendar#index", as: "training_calendar"
+  get "training/week/:year/:number", to: "training_week#index", as: "training_week"
   get "wishlist", to: "wishlist#index"
   get "work_weeks/:target", to: "work_weeks#show", as: :work_week
 
@@ -38,6 +40,7 @@ Rails.application.routes.draw do
 
   resources :boops, only: %i[index create]
   resources :gift_ideas, only: %i[update]
+  resources :training_days, only: %i[create update]
 
   resources :crank_users, only: %i[create new show], param: :code do
     resources :crank_counts, only: %i[create new show]

--- a/spec/fixtures/generators/crud_pages/config/routes.rb
+++ b/spec/fixtures/generators/crud_pages/config/routes.rb
@@ -59,8 +59,11 @@ Rails.application.routes.draw do
     resources :projects
     resources :raw_hooks
     resources :sneakers
+    resources :training_activities
+    resources :training_days
     resources :warm_fuzzies
     resources :webhook_senders
+    resources :workouts
   end
 
   namespace :api, defaults: {format: :json} do

--- a/spec/generator/crud/pages_generator_spec.rb
+++ b/spec/generator/crud/pages_generator_spec.rb
@@ -28,7 +28,7 @@ describe Crud::PagesGenerator, type: :generator do
       actual_filename = actual_path.gsub("tmp/generators", "")
       expected_filename = expected_path.gsub("spec/fixtures/generators", "")
       expect(actual_filename).to eq expected_filename
-      # bundle exec rake update_snapshots
+      # bin/rake update_snapshots
       expect(FileUtils.compare_file(actual_path, expected_path)).to eq true
     end
   end

--- a/spec/models/daily_packet/pdf_view_spec.rb
+++ b/spec/models/daily_packet/pdf_view_spec.rb
@@ -28,7 +28,8 @@ describe DailyPacket::PdfView do
           "7.7 pages/day",
           "Feedbin Stats",
           "unread: 9",
-          "oldest: 14 days ago"
+          "oldest: 14 days ago",
+          "November Workouts"
         ])
 
         expect(page_two_strings).to eq([

--- a/spec/models/training_activity_spec.rb
+++ b/spec/models/training_activity_spec.rb
@@ -1,0 +1,24 @@
+require "rails_helper"
+
+describe TrainingActivity do
+  describe "validation" do
+    context "without required attributes" do
+      it "is not valid" do
+        training_activity = TrainingActivity.create
+        expect(training_activity).to_not be_valid
+      end
+    end
+
+    context "with required attributes" do
+      it "is valid" do
+        workout = FactoryBot.create(:workout)
+        training_day = FactoryBot.create(:training_day)
+        training_activity = TrainingActivity.create(
+          training_day: training_day,
+          workout: workout
+        )
+        expect(training_activity).to be_valid
+      end
+    end
+  end
+end

--- a/spec/models/training_day/calendar_report_spec.rb
+++ b/spec/models/training_day/calendar_report_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+
+describe TrainingDay::CalendarReport do
+  describe "#training_day_groups" do
+    context "with no matching TrainingDay records" do
+      it "returns an empty array" do
+        report = TrainingDay::CalendarReport.new(2026, 5)
+        expect(report.training_day_groups).to eq([])
+      end
+    end
+
+    context "with matching TrainingDay records" do
+      it "returns those matching records and filler" do
+        TrainingDay.populate(2026, 5)
+        report = TrainingDay::CalendarReport.new(2026, 5)
+
+        date_strings = report.training_day_groups.map do |training_day_group|
+          training_day_group.map { |training_day| training_day.date.to_fs }
+        end
+
+        expect(date_strings).to eq([
+          ["04/26/2026", "04/27/2026", "04/28/2026", "04/29/2026", "04/30/2026", "05/01/2026", "05/02/2026"],
+          ["05/03/2026", "05/04/2026", "05/05/2026", "05/06/2026", "05/07/2026", "05/08/2026", "05/09/2026"],
+          ["05/10/2026", "05/11/2026", "05/12/2026", "05/13/2026", "05/14/2026", "05/15/2026", "05/16/2026"],
+          ["05/17/2026", "05/18/2026", "05/19/2026", "05/20/2026", "05/21/2026", "05/22/2026", "05/23/2026"],
+          ["05/24/2026", "05/25/2026", "05/26/2026", "05/27/2026", "05/28/2026", "05/29/2026", "05/30/2026"],
+          ["05/31/2026", "06/01/2026", "06/02/2026", "06/03/2026", "06/04/2026", "06/05/2026", "06/06/2026"]
+        ])
+      end
+    end
+  end
+end

--- a/spec/models/training_day/filler_day_spec.rb
+++ b/spec/models/training_day/filler_day_spec.rb
@@ -1,0 +1,70 @@
+require "rails_helper"
+
+describe TrainingDay::FillerDay do
+  describe ".fill_after" do
+    context "with a date that is not the end of the month" do
+      it "returns an empty array" do
+        date = Date.new(2026, 5, 4)
+        filler_days = TrainingDay::FillerDay.fill_after(date)
+        expect(filler_days).to eq([])
+      end
+    end
+
+    context "with a date that is the end of the month" do
+      it "returns filled days" do
+        date = Date.new(2026, 5, 31)
+        filler_days = TrainingDay::FillerDay.fill_after(date)
+        dates = filler_days.map(&:date).map(&:to_fs)
+        expect(dates).to eq([
+          "06/01/2026",
+          "06/02/2026",
+          "06/03/2026",
+          "06/04/2026",
+          "06/05/2026",
+          "06/06/2026"
+        ])
+      end
+    end
+
+    context "with a date that is the end of the month but needs no filler" do
+      it "returns an empty array" do
+        date = Date.new(2026, 2, 28)
+        filler_days = TrainingDay::FillerDay.fill_after(date)
+        expect(filler_days).to eq([])
+      end
+    end
+  end
+
+  describe ".fill_before" do
+    context "with a date that is not the beginning of the month" do
+      it "returns an empty array" do
+        date = Date.new(2026, 5, 4)
+        filler_days = TrainingDay::FillerDay.fill_before(date)
+        expect(filler_days).to eq([])
+      end
+    end
+
+    context "with a date that is the beginning of the month" do
+      it "returns filled days" do
+        date = Date.new(2026, 5, 1)
+        filler_days = TrainingDay::FillerDay.fill_before(date)
+        dates = filler_days.map(&:date).map(&:to_fs)
+        expect(dates).to eq([
+          "04/26/2026",
+          "04/27/2026",
+          "04/28/2026",
+          "04/29/2026",
+          "04/30/2026"
+        ])
+      end
+    end
+
+    context "with a date that is the beginning of the month but needs no filler" do
+      it "returns an empty array" do
+        date = Date.new(2026, 2, 1)
+        filler_days = TrainingDay::FillerDay.fill_after(date)
+        expect(filler_days).to eq([])
+      end
+    end
+  end
+end

--- a/spec/models/training_day_spec.rb
+++ b/spec/models/training_day_spec.rb
@@ -1,0 +1,34 @@
+require "rails_helper"
+
+describe TrainingDay do
+  describe "validation" do
+    context "without required attributes" do
+      it "is not valid" do
+        training_day = TrainingDay.create
+        expect(training_day).to_not be_valid
+      end
+    end
+
+    context "with required attributes" do
+      it "is valid" do
+        training_day = TrainingDay.create(
+          date: Date.new,
+          intensity: "lift",
+          with_coach: false
+        )
+        expect(training_day).to be_valid
+      end
+    end
+
+    context "with invalid intensity" do
+      it "is not valid" do
+        training_day = TrainingDay.create(
+          date: Date.new,
+          intensity: "invalid",
+          with_coach: false
+        )
+        expect(training_day).to_not be_valid
+      end
+    end
+  end
+end

--- a/spec/models/workout_spec.rb
+++ b/spec/models/workout_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+describe Workout do
+  describe "validation" do
+    context "without required attributes" do
+      it "is not valid" do
+        workout = Workout.create
+        expect(workout).to_not be_valid
+      end
+    end
+
+    context "with required attributes" do
+      it "is valid" do
+        workout = Workout.create(
+          title: "Warm Up"
+        )
+        expect(workout).to be_valid
+      end
+    end
+  end
+end

--- a/spec/system/crud/training_activities/admin_creates_training_activity_spec.rb
+++ b/spec/system/crud/training_activities/admin_creates_training_activity_spec.rb
@@ -1,0 +1,47 @@
+require "rails_helper"
+
+describe "Admin creates training activity" do
+  include_context "admin password matches"
+
+  scenario "from list page" do
+    visit "/crud/training_activities"
+    click_on "New Training Activity"
+    expect(page).to have_css "h1", text: "New Training Activity"
+    expect(page).to have_css "a", text: "Training Activity List"
+    expect(page).to have_current_path new_crud_training_activity_path
+  end
+
+  scenario "create with errors" do
+    visit "/crud/training_activities/new"
+    click_on "create"
+    expect(page).to have_css ".alert", text: "Training day must exist and Workout must exist"
+    expect(page).to have_current_path new_crud_training_activity_path
+  end
+
+  scenario "create successfully" do
+    training_day = FactoryBot.create(:training_day)
+    workout = FactoryBot.create(:workout)
+    visit "/crud/training_activities/new"
+    fill_in "training_day_id", with: training_day.id
+    fill_in "workout_id", with: workout.id
+    click_on "create"
+
+    expect(page).to have_css ".notice", text: "Training Activity created"
+
+    training_activity = TrainingActivity.last
+    expect(page).to have_current_path crud_training_activity_path(training_activity)
+
+    actual_values = page.all("tr").map do |table_row|
+      table_row.all("td").map(&:text)
+    end
+
+    expect(actual_values).to eq(
+      [
+        ["Training Day ID", training_day.id.to_s],
+        ["Workout ID", workout.id.to_s],
+        ["Created At", training_activity.created_at.to_fs],
+        ["Updated At", training_activity.updated_at.to_fs]
+      ]
+    )
+  end
+end

--- a/spec/system/crud/training_activities/admin_edits_training_activity_spec.rb
+++ b/spec/system/crud/training_activities/admin_edits_training_activity_spec.rb
@@ -1,0 +1,40 @@
+require "rails_helper"
+
+describe "Admin edits training activity" do
+  include_context "admin password matches"
+
+  scenario "from show page" do
+    training_activity = FactoryBot.create(:training_activity)
+    visit "/crud/training_activities/#{training_activity.id}"
+    click_on "Edit Training Activity"
+    expect(page).to have_css "h1", text: "Edit Training Activity #{training_activity.id}"
+    expect(page).to have_css "a", text: "Show Training Activity"
+    expect(page).to have_current_path edit_crud_training_activity_path(training_activity)
+  end
+
+  scenario "edit with errors" do
+    training_activity = FactoryBot.create(:training_activity)
+    visit "/crud/training_activities/#{training_activity.id}/edit"
+    fill_in "training_day_id", with: ""
+    click_on "update"
+    expect(page).to have_css ".alert", text: "Training day must exist"
+  end
+
+  scenario "edit successfully" do
+    initial_training_day = FactoryBot.create(:training_day, date: Date.today)
+    updated_training_day = FactoryBot.create(:training_day, date: Date.yesterday)
+
+    training_activity = FactoryBot.create(
+      :training_activity,
+      training_day: initial_training_day,
+      workout: FactoryBot.create(:workout)
+    )
+    visit "/crud/training_activities/#{training_activity.id}/edit"
+    fill_in "training_day_id", with: updated_training_day.id
+    click_on "update"
+
+    expect(page).to have_css ".notice", text: "Training Activity updated"
+    expect(page).to have_current_path crud_training_activity_path(training_activity)
+    expect(page).to have_css "td", text: updated_training_day.id.to_s
+  end
+end

--- a/spec/system/crud/training_activities/admin_views_training_activities_spec.rb
+++ b/spec/system/crud/training_activities/admin_views_training_activities_spec.rb
@@ -1,0 +1,41 @@
+require "rails_helper"
+
+describe "Admin views training activities" do
+  include_context "admin password matches"
+
+  scenario "from dashboard" do
+    visit "/dashboard"
+    click_on "Training Activities"
+    expect(page).to have_css "h1", text: "Training Activities"
+    expect(page).to have_current_path crud_training_activities_path
+  end
+
+  scenario "with no records" do
+    visit "/crud/training_activities"
+    expect(page.all("tbody tr").count).to eq 0
+  end
+
+  scenario "with a page of records" do
+    (1..3).each do |offset|
+      FactoryBot.create(
+        :training_activity,
+        training_day: FactoryBot.create(:training_day, date: Date.today + offset.days)
+      )
+    end
+    visit "/crud/training_activities"
+    expect(page.all("tbody tr").count).to eq 3
+    expect(page).to_not have_css "nav.pagination"
+  end
+
+  scenario "with two pages of records" do
+    (1..4).each do |offset|
+      FactoryBot.create(
+        :training_activity,
+        training_day: FactoryBot.create(:training_day, date: Date.today + offset.days)
+      )
+    end
+    visit "/crud/training_activities"
+    expect(page.all("tbody tr").count).to eq 3
+    expect(page).to have_css "nav.pagination"
+  end
+end

--- a/spec/system/crud/training_activities/admin_views_training_activity_spec.rb
+++ b/spec/system/crud/training_activities/admin_views_training_activity_spec.rb
@@ -1,0 +1,50 @@
+require "rails_helper"
+
+describe "Admin views training activity" do
+  include_context "admin password matches"
+
+  scenario "from list page" do
+    training_activity = FactoryBot.create(:training_activity)
+    visit "/crud/training_activities"
+    click_on training_activity.id.to_s
+    expect(page).to have_css "h1", text: "Training Activity #{training_activity.id}"
+    expect(page).to have_css "a", text: "Training Activity List"
+    expect(page).to have_current_path crud_training_activity_path(training_activity)
+  end
+
+  scenario "viewing a record" do
+    training_day = FactoryBot.create(:training_day)
+    workout = FactoryBot.create(:workout)
+    training_activity = FactoryBot.create(
+      :training_activity,
+      training_day: training_day,
+      workout: workout
+    )
+
+    visit "/crud/training_activities/#{training_activity.id}"
+
+    actual_values = page.all("tr").map do |table_row|
+      table_row.all("td").map(&:text)
+    end
+
+    expect(actual_values).to eq(
+      [
+        ["Training Day ID", training_day.id.to_s],
+        ["Workout ID", workout.id.to_s],
+        ["Created At", training_activity.created_at.to_fs],
+        ["Updated At", training_activity.updated_at.to_fs]
+      ]
+    )
+  end
+
+  scenario "views random record" do
+    training_activity = FactoryBot.create(:training_activity)
+    expect(TrainingActivity).to receive(:random).and_return(training_activity)
+
+    visit "/crud/training_activities"
+    click_on "Random Training Activity"
+
+    expect(page).to have_css "h1", text: "Training Activity #{training_activity.id}"
+    expect(page).to have_current_path crud_training_activity_path(training_activity)
+  end
+end

--- a/spec/system/crud/training_days/admin_creates_training_day_spec.rb
+++ b/spec/system/crud/training_days/admin_creates_training_day_spec.rb
@@ -1,0 +1,48 @@
+require "rails_helper"
+
+describe "Admin creates training day" do
+  include_context "admin password matches"
+
+  scenario "from list page" do
+    visit "/crud/training_days"
+    click_on "New Training Day"
+    expect(page).to have_css "h1", text: "New Training Day"
+    expect(page).to have_css "a", text: "Training Day List"
+    expect(page).to have_current_path new_crud_training_day_path
+  end
+
+  scenario "create with errors" do
+    visit "/crud/training_days/new"
+    click_on "create"
+    expect(page).to have_css ".alert", text: "Date can't be blank, Intensity can't be blank, Intensity is not included in the list, and With coach is not included in the list"
+    expect(page).to have_current_path new_crud_training_day_path
+  end
+
+  scenario "create successfully" do
+    visit "/crud/training_days/new"
+    fill_in "date", with: "01/01/2000"
+    select "lift", from: "training_day_intensity"
+    select "true", from: "training_day_with_coach"
+    click_on "create"
+
+    expect(page).to have_css ".notice", text: "Training Day created"
+
+    training_day = TrainingDay.last
+    expect(page).to have_current_path crud_training_day_path(training_day)
+
+    actual_values = page.all("tr").map do |table_row|
+      table_row.all("td").map(&:text)
+    end
+
+    expect(actual_values).to eq(
+      [
+        ["Date", "01/01/2000"],
+        ["Intensity", "lift"],
+        ["With Coach", "true"],
+        ["Completed At", "NIL"],
+        ["Created At", training_day.created_at.to_fs],
+        ["Updated At", training_day.updated_at.to_fs]
+      ]
+    )
+  end
+end

--- a/spec/system/crud/training_days/admin_edits_training_day_spec.rb
+++ b/spec/system/crud/training_days/admin_edits_training_day_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe "Admin edits training day" do
+  include_context "admin password matches"
+
+  scenario "from show page" do
+    training_day = FactoryBot.create(:training_day)
+    visit "/crud/training_days/#{training_day.id}"
+    click_on "Edit Training Day"
+    expect(page).to have_css "h1", text: "Edit Training Day #{training_day.id}"
+    expect(page).to have_css "a", text: "Show Training Day"
+    expect(page).to have_current_path edit_crud_training_day_path(training_day)
+  end
+
+  scenario "edit with errors" do
+    training_day = FactoryBot.create(:training_day)
+    visit "/crud/training_days/#{training_day.id}/edit"
+    select "please select", from: "training_day_intensity"
+    click_on "update"
+    expect(page).to have_css ".alert", text: "Intensity can't be blank and Intensity is not included in the list"
+  end
+
+  scenario "edit successfully" do
+    training_day = FactoryBot.create(
+      :training_day,
+      intensity: "rest"
+    )
+    visit "/crud/training_days/#{training_day.id}/edit"
+    select "lift", from: "training_day_intensity"
+    click_on "update"
+
+    expect(page).to have_css ".notice", text: "Training Day updated"
+    expect(page).to have_current_path crud_training_day_path(training_day)
+    expect(page).to have_css "td", text: "lift"
+  end
+end

--- a/spec/system/crud/training_days/admin_views_training_day_spec.rb
+++ b/spec/system/crud/training_days/admin_views_training_day_spec.rb
@@ -1,0 +1,51 @@
+require "rails_helper"
+
+describe "Admin views training day" do
+  include_context "admin password matches"
+
+  scenario "from list page" do
+    training_day = FactoryBot.create(:training_day)
+    visit "/crud/training_days"
+    click_on training_day.id.to_s
+    expect(page).to have_css "h1", text: "Training Day #{training_day.id}"
+    expect(page).to have_css "a", text: "Training Day List"
+    expect(page).to have_current_path crud_training_day_path(training_day)
+  end
+
+  scenario "viewing a record" do
+    training_day = FactoryBot.create(
+      :training_day,
+      date: Date.today,
+      intensity: "lift",
+      with_coach: true
+    )
+
+    visit "/crud/training_days/#{training_day.id}"
+
+    actual_values = page.all("tr").map do |table_row|
+      table_row.all("td").map(&:text)
+    end
+
+    expect(actual_values).to eq(
+      [
+        ["Date", training_day.date.to_fs],
+        ["Intensity", "lift"],
+        ["With Coach", "true"],
+        ["Completed At", "NIL"],
+        ["Created At", training_day.created_at.to_fs],
+        ["Updated At", training_day.updated_at.to_fs]
+      ]
+    )
+  end
+
+  scenario "views random record" do
+    training_day = FactoryBot.create(:training_day)
+    expect(TrainingDay).to receive(:random).and_return(training_day)
+
+    visit "/crud/training_days"
+    click_on "Random Training Day"
+
+    expect(page).to have_css "h1", text: "Training Day #{training_day.id}"
+    expect(page).to have_current_path crud_training_day_path(training_day)
+  end
+end

--- a/spec/system/crud/training_days/admin_views_training_days_spec.rb
+++ b/spec/system/crud/training_days/admin_views_training_days_spec.rb
@@ -1,0 +1,35 @@
+require "rails_helper"
+
+describe "Admin views training days" do
+  include_context "admin password matches"
+
+  scenario "from dashboard" do
+    visit "/dashboard"
+    click_on "Training Days"
+    expect(page).to have_css "h1", text: "Training Days"
+    expect(page).to have_current_path crud_training_days_path
+  end
+
+  scenario "with no records" do
+    visit "/crud/training_days"
+    expect(page.all("tbody tr").count).to eq 0
+  end
+
+  scenario "with a page of records" do
+    (1..3).each do |offset|
+      FactoryBot.create(:training_day, date: Date.today + offset.days)
+    end
+    visit "/crud/training_days"
+    expect(page.all("tbody tr").count).to eq 3
+    expect(page).to_not have_css "nav.pagination"
+  end
+
+  scenario "with two pages of records" do
+    (1..4).each do |offset|
+      FactoryBot.create(:training_day, date: Date.today + offset.days)
+    end
+    visit "/crud/training_days"
+    expect(page.all("tbody tr").count).to eq 3
+    expect(page).to have_css "nav.pagination"
+  end
+end

--- a/spec/system/crud/workouts/admin_creates_workout_spec.rb
+++ b/spec/system/crud/workouts/admin_creates_workout_spec.rb
@@ -1,0 +1,43 @@
+require "rails_helper"
+
+describe "Admin creates workout" do
+  include_context "admin password matches"
+
+  scenario "from list page" do
+    visit "/crud/workouts"
+    click_on "New Workout"
+    expect(page).to have_css "h1", text: "New Workout"
+    expect(page).to have_css "a", text: "Workout List"
+    expect(page).to have_current_path new_crud_workout_path
+  end
+
+  scenario "create with errors" do
+    visit "/crud/workouts/new"
+    click_on "create"
+    expect(page).to have_css ".alert", text: "Title can't be blank"
+    expect(page).to have_current_path new_crud_workout_path
+  end
+
+  scenario "create successfully" do
+    visit "/crud/workouts/new"
+    fill_in "title", with: "Warm Up"
+    click_on "create"
+
+    expect(page).to have_css ".notice", text: "Workout created"
+
+    workout = Workout.last
+    expect(page).to have_current_path crud_workout_path(workout)
+
+    actual_values = page.all("tr").map do |table_row|
+      table_row.all("td").map(&:text)
+    end
+
+    expect(actual_values).to eq(
+      [
+        ["Title", "Warm Up"],
+        ["Created At", workout.created_at.to_fs],
+        ["Updated At", workout.updated_at.to_fs]
+      ]
+    )
+  end
+end

--- a/spec/system/crud/workouts/admin_edits_workout_spec.rb
+++ b/spec/system/crud/workouts/admin_edits_workout_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+describe "Admin edits workout" do
+  include_context "admin password matches"
+
+  scenario "from show page" do
+    workout = FactoryBot.create(:workout)
+    visit "/crud/workouts/#{workout.id}"
+    click_on "Edit Workout"
+    expect(page).to have_css "h1", text: "Edit Workout #{workout.id}"
+    expect(page).to have_css "a", text: "Show Workout"
+    expect(page).to have_current_path edit_crud_workout_path(workout)
+  end
+
+  scenario "edit with errors" do
+    workout = FactoryBot.create(:workout)
+    visit "/crud/workouts/#{workout.id}/edit"
+    fill_in "title", with: ""
+    click_on "update"
+    expect(page).to have_css ".alert", text: "Title can't be blank"
+  end
+
+  scenario "edit successfully" do
+    workout = FactoryBot.create(
+      :workout,
+      title: "Warm Down"
+    )
+    visit "/crud/workouts/#{workout.id}/edit"
+    fill_in "title", with: "Warm Up"
+    click_on "update"
+
+    expect(page).to have_css ".notice", text: "Workout updated"
+    expect(page).to have_current_path crud_workout_path(workout)
+    expect(page).to have_css "td", text: "Warm Up"
+  end
+end

--- a/spec/system/crud/workouts/admin_views_workout_spec.rb
+++ b/spec/system/crud/workouts/admin_views_workout_spec.rb
@@ -1,0 +1,46 @@
+require "rails_helper"
+
+describe "Admin views workout" do
+  include_context "admin password matches"
+
+  scenario "from list page" do
+    workout = FactoryBot.create(:workout)
+    visit "/crud/workouts"
+    click_on workout.id.to_s
+    expect(page).to have_css "h1", text: "Workout #{workout.id}"
+    expect(page).to have_css "a", text: "Workout List"
+    expect(page).to have_current_path crud_workout_path(workout)
+  end
+
+  scenario "viewing a record" do
+    workout = FactoryBot.create(
+      :workout,
+      title: "Warm Up"
+    )
+
+    visit "/crud/workouts/#{workout.id}"
+
+    actual_values = page.all("tr").map do |table_row|
+      table_row.all("td").map(&:text)
+    end
+
+    expect(actual_values).to eq(
+      [
+        ["Title", "Warm Up"],
+        ["Created At", workout.created_at.to_fs],
+        ["Updated At", workout.updated_at.to_fs]
+      ]
+    )
+  end
+
+  scenario "views random record" do
+    workout = FactoryBot.create(:workout)
+    expect(Workout).to receive(:random).and_return(workout)
+
+    visit "/crud/workouts"
+    click_on "Random Workout"
+
+    expect(page).to have_css "h1", text: "Workout #{workout.id}"
+    expect(page).to have_current_path crud_workout_path(workout)
+  end
+end

--- a/spec/system/crud/workouts/admin_views_workouts_spec.rb
+++ b/spec/system/crud/workouts/admin_views_workouts_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+describe "Admin views workouts" do
+  include_context "admin password matches"
+
+  scenario "from dashboard" do
+    visit "/dashboard"
+    click_on "Workouts"
+    expect(page).to have_css "h1", text: "Workouts"
+    expect(page).to have_current_path crud_workouts_path
+  end
+
+  scenario "with no records" do
+    visit "/crud/workouts"
+    expect(page.all("tbody tr").count).to eq 0
+  end
+
+  scenario "with a page of records" do
+    FactoryBot.create_list(:workout, 3)
+    visit "/crud/workouts"
+    expect(page.all("tbody tr").count).to eq 3
+    expect(page).to_not have_css "nav.pagination"
+  end
+
+  scenario "with two pages of records" do
+    FactoryBot.create_list(:workout, 4)
+    visit "/crud/workouts"
+    expect(page.all("tbody tr").count).to eq 3
+    expect(page).to have_css "nav.pagination"
+  end
+end

--- a/spec/system/model_counts/admin_views_model_counts_spec.rb
+++ b/spec/system/model_counts/admin_views_model_counts_spec.rb
@@ -32,9 +32,12 @@ describe "Admin views model counts" do
       "Project 0",
       "RawHook 0",
       "Sneaker 0",
+      "TrainingActivity 0",
+      "TrainingDay 0",
       "WarmFuzzy 0",
       "WebhookSender 0",
-      "WorkDay 0"
+      "WorkDay 0",
+      "Workout 0"
     ]
 
     expect(actual_rows).to match_array(expected_rows)
@@ -53,6 +56,12 @@ describe "Admin views model counts" do
     FactoryBot.create(:project)
     FactoryBot.create(:sneaker)
     FactoryBot.create(:work_day)
+
+    FactoryBot.create(
+      :training_activity,
+      training_day: FactoryBot.create(:training_day),
+      workout: FactoryBot.create(:workout)
+    )
 
     FactoryBot.create(
       :crank_count,
@@ -109,13 +118,16 @@ describe "Admin views model counts" do
       "Project 1",
       "RawHook 1",
       "Sneaker 1",
+      "TrainingActivity 1",
+      "TrainingDay 1",
       "WarmFuzzy 1",
       "WebhookSender 1",
-      "WorkDay 1"
+      "WorkDay 1",
+      "Workout 1"
     ]
 
     expect(actual_rows).to match_array(expected_rows)
 
-    expect(page.find("tfoot tr").text).to eq "Total 26"
+    expect(page.find("tfoot tr").text).to eq "Total 29"
   end
 end


### PR DESCRIPTION
This PR lands a new area of the app that I'll use to track my workouts and training. I'm starting off with a calendar view where I can drill into individual weeks. The week view is where I expect to spend most of my time tinkering with which days I'm lifting vs recovery days. Then I also added a section to the Daily Packet so I'm kinda excited to see how this keeps me motivated and engaged with my fitness goals.