### PR TITLE
Bundle update and fix script

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -83,8 +83,8 @@ GEM
     afm (1.0.0)
     ast (2.4.3)
     aws-eventstream (1.4.0)
-    aws-partitions (1.1253.0)
-    aws-sdk-core (3.249.0)
+    aws-partitions (1.1257.0)
+    aws-sdk-core (3.251.0)
       aws-eventstream (~> 1, >= 1.3.0)
       aws-partitions (~> 1, >= 1.992.0)
       aws-sigv4 (~> 1.9)
@@ -92,10 +92,10 @@ GEM
       bigdecimal
       jmespath (~> 1, >= 1.6.1)
       logger
-    aws-sdk-kms (1.128.0)
+    aws-sdk-kms (1.129.0)
       aws-sdk-core (~> 3, >= 3.248.0)
       aws-sigv4 (~> 1.5)
-    aws-sdk-s3 (1.224.0)
+    aws-sdk-s3 (1.225.0)
       aws-sdk-core (~> 3, >= 3.248.0)
       aws-sdk-kms (~> 1)
       aws-sigv4 (~> 1.5)
@@ -147,7 +147,7 @@ GEM
       logger
     faraday-follow_redirects (0.5.0)
       faraday (>= 1, < 3)
-    faraday-net_http (3.4.3)
+    faraday-net_http (3.4.4)
       net-http (~> 0.5)
     fiber-storage (1.0.1)
     fugit (1.12.2)
@@ -168,7 +168,7 @@ GEM
       tilt
     hashdiff (1.2.1)
     hashery (2.1.2)
-    honeybadger (6.6.1)
+    honeybadger (6.6.2)
       logger
       ostruct
     i18n (1.14.8)
@@ -187,7 +187,7 @@ GEM
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
     jmespath (1.6.2)
-    json (2.19.7)
+    json (2.19.8)
     jwt (3.2.0)
       base64
     kaminari (1.2.2)
@@ -294,7 +294,7 @@ GEM
       reline (>= 0.6.0)
     pry-rails (0.3.11)
       pry (>= 0.13.0)
-    psych (5.3.1)
+    psych (5.4.0)
       date
       stringio
     public_suffix (7.0.5)
@@ -395,7 +395,7 @@ GEM
       rexml
     ruby-progressbar (1.13.0)
     ruby-rc4 (0.1.5)
-    rubyzip (3.3.0)
+    rubyzip (3.3.1)
     securerandom (0.4.1)
     selenium-webdriver (4.44.0)
       base64 (~> 0.2)

--- a/bin/update
+++ b/bin/update
@@ -11,7 +11,7 @@ Dependency Updates
 This commit updates project dependencies like this:
 
 ```
-$ bundle update
+$ bundle update --all
 ```
 
 It was automatically created with this script:
@@ -24,7 +24,7 @@ END
 
 git fetch --all --quiet
 git checkout -b updates
-bundle update
+bundle update --all
 bundle exec rake
 git add .
 git commit --message "$message"


### PR DESCRIPTION
I wanted to do an update PR today because I'm migrating to a newer Heroku stack and it needs to be deployed in order for the new stack to kick in. I figure this is a minor change so a good candidate. While I was at it, I noticed that `bundle update --all` is the new way to do that so I also updated the script.